### PR TITLE
[Bots] Command Cleanup

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -743,7 +743,7 @@ namespace BotSpellTypes
 	constexpr uint16	DISCIPLINE_END             = BotSpellTypes::DiscUtility;      // Do not remove this, increment as needed
 }
 
-static std::map<uint16, std::string> spellType_names = {
+static std::map<uint16, std::string> spell_type_names = {
 	{ BotSpellTypes::Nuke,                     "Nuke" },
 	{ BotSpellTypes::RegularHeal,              "Regular Heal" },
 	{ BotSpellTypes::Root,                     "Root" },
@@ -818,7 +818,7 @@ static std::map<uint16, std::string> spellType_names = {
 	{ BotSpellTypes::AELull,                   "AE Lull" }
 };
 
-static std::map<uint16, std::string> spellType_shortNames = {
+static std::map<uint16, std::string> spell_type_short_names = {
 	{ BotSpellTypes::Nuke,                     "nukes" },
 	{ BotSpellTypes::RegularHeal,              "regularheals" },
 	{ BotSpellTypes::Root,                     "roots" },

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -8353,12 +8353,13 @@ void Bot::ListBotSpells(uint8 min_level)
 			bot_owner->Message(
 				Chat::White,
 				fmt::format(
-					"Spell {} | Spell: {} | Add Spell: {}",
+					"Spell {} | Spell: {} (ID: {}) | Add Spell: {}",
 					spell_number,
 					Saylink::Silent(
 						fmt::format("^spellinfo {}", s.spellid),
 						spells[s.spellid].name
 					),
+					s.spellid,
 					Saylink::Silent(
 						fmt::format("^spellsettingsadd {} {} {} {}", s.spellid, s.priority, s.min_hp, s.max_hp), "Add")
 				).c_str()
@@ -12077,182 +12078,6 @@ bool Bot::HasValidAETarget(Bot* caster, uint16 spell_id, uint16 spell_type, Mob*
 	return true;
 }
 
-void Bot::CopySettings(Bot* to, uint8 setting_type, uint16 spell_type) {
-	switch (setting_type) {
-		case BotSettingCategories::BaseSetting:
-			for (uint16 i = BotBaseSettings::START; i <= BotBaseSettings::END; ++i) {
-				to->SetBotBaseSetting(i, GetBotBaseSetting(i));
-			}
-
-			break;
-		case BotSettingCategories::SpellHold:
-			if (spell_type != UINT16_MAX) {
-				to->SetSpellTypeHold(spell_type, GetSpellTypeHold(spell_type));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					to->SetSpellTypeHold(i, GetSpellTypeHold(i));
-				}
-			}
-
-			break;
-		case BotSettingCategories::SpellDelay:
-			if (spell_type != UINT16_MAX) {
-				to->SetSpellTypeDelay(spell_type, GetSpellTypeDelay(spell_type));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					to->SetSpellTypeDelay(i, GetSpellTypeDelay(i));
-				}
-			}
-
-			break;
-		case BotSettingCategories::SpellMinThreshold:
-			if (spell_type != UINT16_MAX) {
-				to->SetSpellTypeMinThreshold(spell_type, GetSpellTypeMinThreshold(spell_type));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					to->SetSpellTypeMinThreshold(i, GetSpellTypeMinThreshold(i));
-				}
-			}
-
-			break;
-		case BotSettingCategories::SpellMaxThreshold:
-			if (spell_type != UINT16_MAX) {
-				to->SetSpellTypeMaxThreshold(spell_type, GetSpellTypeMaxThreshold(spell_type));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					to->SetSpellTypeMaxThreshold(i, GetSpellTypeMaxThreshold(i));
-				}
-			}
-
-			break;
-		case BotSettingCategories::SpellTypeAggroCheck:
-			if (spell_type != UINT16_MAX) {
-				to->SetSpellTypeAggroCheck(spell_type, GetSpellTypeAggroCheck(spell_type));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					to->SetSpellTypeAggroCheck(i, GetSpellTypeAggroCheck(i));
-				}
-			}
-
-			break;
-		case BotSettingCategories::SpellTypeResistLimit:
-			if (spell_type != UINT16_MAX) {
-				to->SetSpellTypeResistLimit(spell_type, GetSpellTypeResistLimit(spell_type));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					to->SetSpellTypeResistLimit(i, GetSpellTypeResistLimit(i));
-				}
-			}
-
-			break;
-		case BotSettingCategories::SpellTypeMinManaPct:
-			if (spell_type != UINT16_MAX) {
-				to->SetSpellTypeMinManaLimit(spell_type, GetSpellTypeMinManaLimit(spell_type));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					to->SetSpellTypeMinManaLimit(i, GetSpellTypeMinManaLimit(i));
-				}
-			}
-
-			break;
-		case BotSettingCategories::SpellTypeMaxManaPct:
-			if (spell_type != UINT16_MAX) {
-				to->SetSpellTypeMaxManaLimit(spell_type, GetSpellTypeMaxManaLimit(spell_type));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					to->SetSpellTypeMaxManaLimit(i, GetSpellTypeMaxManaLimit(i));
-				}
-			}
-
-			break;
-		case BotSettingCategories::SpellTypeMinHPPct:
-			if (spell_type != UINT16_MAX) {
-				to->SetSpellTypeMinHPLimit(spell_type, GetSpellTypeMinHPLimit(spell_type));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					to->SetSpellTypeMinHPLimit(i, GetSpellTypeMinHPLimit(i));
-				}
-			}
-
-			break;
-		case BotSettingCategories::SpellTypeMaxHPPct:
-			if (spell_type != UINT16_MAX) {
-				to->SetSpellTypeMaxHPLimit(spell_type, GetSpellTypeMaxHPLimit(spell_type));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					to->SetSpellTypeMaxHPLimit(i, GetSpellTypeMaxHPLimit(i));
-				}
-			}
-
-			break;
-		case BotSettingCategories::SpellTypeIdlePriority:
-			if (spell_type != UINT16_MAX) {
-				to->SetSpellTypePriority(spell_type, BotPriorityCategories::Idle, GetSpellTypePriority(spell_type, BotPriorityCategories::Idle));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					to->SetSpellTypePriority(i, BotPriorityCategories::Idle, GetSpellTypePriority(i, BotPriorityCategories::Idle));
-				}
-			}
-
-			break;
-		case BotSettingCategories::SpellTypeEngagedPriority:
-			if (spell_type != UINT16_MAX) {
-				to->SetSpellTypePriority(spell_type, BotPriorityCategories::Engaged, GetSpellTypePriority(spell_type, BotPriorityCategories::Engaged));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					to->SetSpellTypePriority(i, BotPriorityCategories::Engaged, GetSpellTypePriority(i, BotPriorityCategories::Engaged));
-				}
-			}
-
-			break;
-		case BotSettingCategories::SpellTypePursuePriority:
-			if (spell_type != UINT16_MAX) {
-				to->SetSpellTypePriority(spell_type, BotPriorityCategories::Pursue, GetSpellTypePriority(spell_type, BotPriorityCategories::Pursue));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					to->SetSpellTypePriority(i, BotPriorityCategories::Pursue, GetSpellTypePriority(i, BotPriorityCategories::Pursue));
-				}
-			}
-
-			break;
-		case BotSettingCategories::SpellTypeAEOrGroupTargetCount:
-			if (spell_type != UINT16_MAX) {
-				to->SetSpellTypeAEOrGroupTargetCount(spell_type, GetSpellTypeAEOrGroupTargetCount(spell_type));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					to->SetSpellTypeAEOrGroupTargetCount(i, GetSpellTypeAEOrGroupTargetCount(i));
-				}
-			}
-
-			break;
-		case BotSettingCategories::SpellTypeAnnounceCast:
-			if (spell_type != UINT16_MAX) {
-				to->SetSpellTypeAnnounceCast(spell_type, GetSpellTypeAnnounceCast(spell_type));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					to->SetSpellTypeAnnounceCast(i, GetSpellTypeAnnounceCast(i));
-				}
-			}
-
-			break;
-	}
-}
-
 void Bot::CopyBotSpellSettings(Bot* to)
 {
 	if (!to) {
@@ -12801,12 +12626,16 @@ bool Bot::IsValidBotSpellCategory(uint8 setting_type) {
 }
 
 std::string Bot::GetBotSpellCategoryName(uint8 setting_type) {
-	return Bot::IsValidBotSpellCategory(setting_type) ? botSpellCategory_names[setting_type] : "UNKNOWN CATEGORY";
+	return Bot::IsValidBotSpellCategory(setting_type) ? bot_setting_category_names[setting_type] : "UNKNOWN CATEGORY";
+}
+
+std::string Bot::GetBotSpellCategoryShortName(uint8 setting_type) {
+	return Bot::IsValidBotSpellCategory(setting_type) ? bot_setting_category_short_names[setting_type] : "UNKNOWN CATEGORY";
 }
 
 uint16 Bot::GetBotSpellCategoryIDByShortName(std::string setting_string) {
 	for (int i = BotSettingCategories::START; i <= BotSettingCategories::END; ++i) {
-		if (!Strings::ToLower(setting_string).compare(Strings::ToLower(GetBotSpellCategoryName(i)))) {
+		if (!Strings::ToLower(setting_string).compare(Strings::ToLower(GetBotSpellCategoryShortName(i)))) {
 			return i;
 		}
 	}
@@ -12833,11 +12662,11 @@ uint16 Bot::GetBaseSettingIDByShortName(std::string setting_string) {
 }
 
 std::string Bot::GetSpellTypeShortNameByID(uint16 spell_type) {
-	return IsValidBotSpellType(spell_type) ? spellType_shortNames[spell_type] : "UNKNOWN SPELLTYPE";
+	return IsValidBotSpellType(spell_type) ? spell_type_short_names[spell_type] : "UNKNOWN SPELLTYPE";
 }
 
 std::string Bot::GetSpellTypeNameByID(uint16 spell_type) {
-	return IsValidBotSpellType(spell_type) ? spellType_names[spell_type] : "UNKNOWN SPELLTYPE";
+	return IsValidBotSpellType(spell_type) ? spell_type_names[spell_type] : "UNKNOWN SPELLTYPE";
 }
 
 bool Bot::IsValidSubType(uint16 sub_type) {

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -93,7 +93,7 @@ enum BotCastingChanceConditional : uint8
 	cntHSND = 16
 };
 
-namespace BotSettingCategories { // Update GetBotSpellCategoryName as needed
+namespace BotSettingCategories {
 	constexpr uint8 BaseSetting                       = 0;
 	constexpr uint8 SpellHold                         = 1;
 	constexpr uint8 SpellDelay                        = 2;
@@ -118,13 +118,32 @@ namespace BotSettingCategories { // Update GetBotSpellCategoryName as needed
 	constexpr uint16 END                              = BotSettingCategories::SpellTypeAnnounceCast;
 };
 
-static std::map<uint8, std::string> botSpellCategory_names = {
+static std::map<uint8, std::string> bot_setting_category_names = {
+	{ BotSettingCategories::BaseSetting,                   "Base Setting" },
+	{ BotSettingCategories::SpellHold,                     "Spell Holds" },
+	{ BotSettingCategories::SpellDelay,                    "Spell Delays" },
+	{ BotSettingCategories::SpellMinThreshold,             "Spell Minimum Thresholds" },
+	{ BotSettingCategories::SpellMaxThreshold,             "Spell Maximum Thresholds" },
+	{ BotSettingCategories::SpellTypeResistLimit,          "Spell Resist Limits" },
+	{ BotSettingCategories::SpellTypeAggroCheck,           "Spell Aggro Checks" },
+	{ BotSettingCategories::SpellTypeMinManaPct,           "Spell Min Mana Percent" },
+	{ BotSettingCategories::SpellTypeMaxManaPct,           "Spell Max Mana Percent" },
+	{ BotSettingCategories::SpellTypeMinHPPct,             "Spell Min HP Percent" },
+	{ BotSettingCategories::SpellTypeMaxHPPct,             "Spell Max HP Percent" },
+	{ BotSettingCategories::SpellTypeIdlePriority,         "Spell Idle Priority" },
+	{ BotSettingCategories::SpellTypeEngagedPriority,      "Spell Engaged Priority" },
+	{ BotSettingCategories::SpellTypePursuePriority,       "Spell Pursue Priority" },
+	{ BotSettingCategories::SpellTypeAEOrGroupTargetCount, "Spell Target Counts" },
+	{ BotSettingCategories::SpellTypeAnnounceCast,         "Spell Announce Casts" }
+};
+
+static std::map<uint8, std::string> bot_setting_category_short_names = {
 	{ BotSettingCategories::BaseSetting,                   "BaseSetting" },
 	{ BotSettingCategories::SpellHold,                     "SpellHolds" },
 	{ BotSettingCategories::SpellDelay,                    "SpellDelays" },
 	{ BotSettingCategories::SpellMinThreshold,             "SpellMinThresholds" },
 	{ BotSettingCategories::SpellMaxThreshold,             "SpellMaxThresholds" },
-	{ BotSettingCategories::SpellTypeResistLimit,          "SpellResistLimit" },
+	{ BotSettingCategories::SpellTypeResistLimit,          "SpellResistLimits" },
 	{ BotSettingCategories::SpellTypeAggroCheck,           "SpellAggroChecks" },
 	{ BotSettingCategories::SpellTypeMinManaPct,           "SpellMinManaPct" },
 	{ BotSettingCategories::SpellTypeMaxManaPct,           "SpellMaxManaPct" },
@@ -137,7 +156,7 @@ static std::map<uint8, std::string> botSpellCategory_names = {
 	{ BotSettingCategories::SpellTypeAnnounceCast,         "SpellAnnounceCasts" }
 };
 
-namespace BotPriorityCategories { // Update GetBotSpellCategoryName as needed
+namespace BotPriorityCategories {
 	constexpr uint8 Idle                              = 0;
 	constexpr uint8 Engaged                           = 1;
 	constexpr uint8 Pursue                            = 2;
@@ -591,7 +610,6 @@ public:
 	void SetBotBaseSetting(uint16 bot_setting, int setting_value);
 	int GetSetting(uint16 setting_category, uint16 setting_type);
 	void SetBotSetting(uint8 setting_type, uint16 bot_setting, int setting_value);
-	void CopySettings(Bot* to, uint8 setting_type, uint16 spell_type = UINT16_MAX);
 	void CopyBotSpellSettings(Bot* to);
 	void ResetBotSpellSettings();
 
@@ -677,6 +695,7 @@ public:
 	bool IsValidSpellTypeSubType(uint16 spell_type, uint16 sub_type, uint16 spell_id);
 	static bool IsValidBotSpellCategory(uint8 setting_type);
 	static std::string GetBotSpellCategoryName(uint8 setting_type);
+	static std::string GetBotSpellCategoryShortName(uint8 setting_type);
 	static uint16 GetBotSpellCategoryIDByShortName(std::string setting_string);
 	void AssignBotSpellsToTypes(std::vector<BotSpells>& AIBot_spells, std::unordered_map<uint16, std::vector<BotSpells_wIndex>>& AIBot_spells_by_type);
 	uint16 GetSpellByAA(int id, AA::Rank*& rank);

--- a/zone/bot_commands/attack.cpp
+++ b/zone/bot_commands/attack.cpp
@@ -53,6 +53,7 @@ void bot_command_attack(Client *c, const Seperator *sep)
 	size_t attacker_count = 0;
 	Bot *first_attacker = nullptr;
 	sbl.erase(std::remove(sbl.begin(), sbl.end(), nullptr), sbl.end());
+
 	for (auto bot_iter : sbl) {
 		if (!bot_iter->ValidStateCheck(c)) {
 			continue;

--- a/zone/bot_commands/behind_mob.cpp
+++ b/zone/bot_commands/behind_mob.cpp
@@ -12,6 +12,7 @@ void bot_command_behind_mob(Client* c, const Seperator* sep)
 		BotCommandHelpParams p;
 
 		p.description = { "Toggles whether or not bots will stay behind the mob during combat." };
+		p.notes = { "- Bots that are taunting will remain in front of their target"};
 		p.example_format = { fmt::format("{} [value] [actionable]", sep->arg[0]) };
 		p.examples_one = 
 		{ 
@@ -84,6 +85,7 @@ void bot_command_behind_mob(Client* c, const Seperator* sep)
 	const int ab_mask = ActionableBots::ABM_Type1;
 	std::string class_race_arg = sep->arg[ab_arg];
 	bool class_race_check = false;
+
 	if (!class_race_arg.compare("byclass") || !class_race_arg.compare("byrace")) {
 		class_race_check = true;
 	}

--- a/zone/bot_commands/blocked_buffs.cpp
+++ b/zone/bot_commands/blocked_buffs.cpp
@@ -9,7 +9,7 @@ void bot_command_blocked_buffs(Client* c, const Seperator* sep)
 	}
 
 	if (helper_command_alias_fail(c, "bot_command_blocked_buffs", sep->arg[0], "blockedbuffs")) {
-		c->Message(Chat::White, "note: Allows you to set, view and wipe blocked buffs for the selected bots.");
+		c->Message(Chat::White, "note: Allows you to set, view and wipe beneficial blocked buffs for the selected bots.");
 
 		return;
 	}
@@ -17,7 +17,7 @@ void bot_command_blocked_buffs(Client* c, const Seperator* sep)
 	if (helper_is_help_or_usage(sep->arg[1])) {
 		BotCommandHelpParams p;
 
-		p.description = { "Allows you to set, view and wipe blocked buffs for the selected bots." };
+		p.description = { "Allows you to set, view and wipe beneficial blocked buffs for the selected bots." };
 		p.notes = { "- You can 'set' spells to be blocked, 'remove' spells from the blocked list, 'list' the current blocked spells or 'wipe' the entire list." };
 		p.example_format = { fmt::format("{} [add [ID] | remove [ID] | list | wipe] [actionable, default: target]", sep->arg[0]) };
 		p.examples_one = 
@@ -231,7 +231,7 @@ void bot_command_blocked_pet_buffs(Client* c, const Seperator* sep)
 	}
 
 	if (helper_command_alias_fail(c, "bot_command_blocked_pet_buffs", sep->arg[0], "blockedpetbuffs")) {
-		c->Message(Chat::White, "note: Allows you to set, view and wipe blocked pet buffs for the selected bots.");
+		c->Message(Chat::White, "note: Allows you to set, view and wipe beneficial blocked pet buffs for the selected bots.");
 
 		return;
 	}
@@ -239,7 +239,7 @@ void bot_command_blocked_pet_buffs(Client* c, const Seperator* sep)
 	if (helper_is_help_or_usage(sep->arg[1])) {
 		BotCommandHelpParams p;
 
-		p.description = { "Allows you to set, view and wipe blocked pet buffs for the selected bots." };
+		p.description = { "Allows you to set, view and wipe beneficial blocked pet buffs for the selected bots." };
 		p.notes =
 		{
 			"- You can 'set' spells to be blocked, 'remove' spells from the blocked list, 'list' the current blocked spells or 'wipe' the entire list.",

--- a/zone/bot_commands/bot.cpp
+++ b/zone/bot_commands/bot.cpp
@@ -480,7 +480,7 @@ void bot_command_follow_distance(Client *c, const Seperator *sep)
 		p.description = { "Sets or resets the follow distance of the selected bots." };
 		p.notes =
 		{
-			fmt::format("[Default]: {}", RuleI(Bots, MaxFollowDistance)),
+			fmt::format("[Default]: {}", RuleI(Bots, DefaultFollowDistance)),
 			fmt::format("- You must use a value between 1 and {}.", RuleI(Bots, MaxFollowDistance))
 		};
 		p.example_format = { fmt::format("{} [reset]/[set [value]] [actionable]", sep->arg[0]) };
@@ -1154,7 +1154,7 @@ void bot_command_stance(Client *c, const Seperator *sep)
 		p.description = { "Change a bot's stance to control the way it behaves." };
 		p.notes = 
 		{
-			"- <b>Changing a stance will reset all settings to match that stance type.</b>",
+			"- Changing a stance will reset all settings to match that stance type.",
 			"- Any changes made will only save to that stance for future use.",
 			fmt::format(
 				"- {} (#{}) will tell Non-Warrior classes to taunt automatically.",
@@ -1182,14 +1182,14 @@ void bot_command_stance(Client *c, const Seperator *sep)
 			),
 			"<br>",
 			fmt::format(
-				"- {} (#{}) [Default] - Overall balance and casts most spell types by default.",
-				Stance::GetName(Stance::Balanced),
-				Stance::Balanced
-			),
-			fmt::format(
 				"- {} (#{}) - Idle. Does not cast or engage in combat.",
 				Stance::GetName(Stance::Passive),
 				Stance::Passive
+			),
+			fmt::format(
+				"- {} (#{}) [Default] - Overall balance and casts most spell types by default.",
+				Stance::GetName(Stance::Balanced),
+				Stance::Balanced
 			),
 			fmt::format(
 				"- {} (#{}) - More mana and aggro efficient (SKs will still cast hate line). Longer delays between detrimental spells, thresholds adjusted to cast less often.",

--- a/zone/bot_commands/copy_settings.cpp
+++ b/zone/bot_commands/copy_settings.cpp
@@ -52,7 +52,7 @@ void bot_command_copy_settings(Client* c, const Seperator* sep)
 			),
 		};
 		p.actionables = { "target, byname, ownergroup, ownerraid, targetgroup, namesgroup, healrotationtargets, mmr, byclass, byrace, spawned" };
-		p.options = { "all, misc, spellsettings, spelltypesettings, spellholds, spelldelays, spellminthresholds, spellmaxthresholds, spellminmanapct, spellmaxmanapct, spellminhppct, spellmaxhppct, spellidlepriority, spellengagedpriority, spellpursuepriority, spellaggrochecks, spelltargetcounts, spellresistlimits, spellannouncecasts, blockedbuffs, blockedpetbuffs" };
+		p.options = { "all, misc, spellsettings, spelltypesettings, spellholds, spelldelays, spellminthresholds, spellmaxthresholds, spellresistlimits, spellaggrochecks, spellminmanapct, spellmaxmanapct, spellminhppct, spellmaxhppct, spellidlepriority, spellengagedpriority, spellpursuepriority, spelltargetcounts, spellannouncecasts, blockedbuffs, blockedpetbuffs" };
 		p.options_one =
 		{
 			"[spellsettings] will copy ^spellsettings options",
@@ -85,12 +85,6 @@ void bot_command_copy_settings(Client* c, const Seperator* sep)
 		return;
 	}
 
-	int spell_type_arg_int = 4;
-	std::string spell_type_arg = sep->arg[spell_type_arg_int];
-	int ab_arg = 2;
-	bool valid_option = false;
-	uint16 spell_type = UINT16_MAX;
-	uint16 setting_type = UINT16_MAX;
 	std::vector<std::string> options =
 	{
 		"all",
@@ -100,63 +94,79 @@ void bot_command_copy_settings(Client* c, const Seperator* sep)
 		"spellholds", 
 		"spelldelays", 
 		"spellminthresholds", 
-		"spellmaxthresholds", 
+		"spellmaxthresholds",
+		"spellresistlimits",
+		"spellaggrochecks",
 		"spellminmanapct", 
 		"spellmaxmanapct", 
 		"spellminhppct", 
 		"spellmaxhppct", 
 		"spellidlepriority", 
 		"spellengagedpriority",
-		"spellpursuepriority", 
-		"spellaggrochecks", 
+		"spellpursuepriority",
 		"spelltargetcounts",
-		"spellresistlimits",
 		"spellannouncecasts",
 		"blockedbuffs", 
 		"blockedpetbuffs"
 	};
 
-	if (sep->IsNumber(spell_type_arg_int)) {
-		spell_type = atoi(sep->arg[spell_type_arg_int]);
-
-		if (!Bot::IsValidBotSpellType(spell_type)) {
-			c->Message(
-				Chat::Yellow,
-				fmt::format(
-					"You must choose a valid spell type. Use {} for information regarding this command.",
-					Saylink::Silent(
-						fmt::format("{} help", sep->arg[0])
-					)
-				).c_str()
-			);
-
-			return;
-		}
-	}
-	else if (!spell_type_arg.empty()) {
-		if (Bot::GetSpellTypeIDByShortName(spell_type_arg) != UINT16_MAX) {
-			spell_type = Bot::GetSpellTypeIDByShortName(spell_type_arg);
-		}
-		else {
-			c->Message(
-				Chat::Yellow,
-				fmt::format(
-					"You must choose a valid spell type. Use {} for information regarding this command.",
-					Saylink::Silent(
-						fmt::format("{} help", sep->arg[0])
-					)
-				).c_str()
-			);
-
-			return;
-		}
-	}
+	std::string option_arg = Strings::ToLower(sep->arg[3]);
+	bool valid_option = false;
+	bool copy_all = false;
+	bool copy_misc = false;
+	bool copy_spell_settings = false;
+	bool copy_spell_type_settings = false;
+	bool copy_blocked_buffs = false;
+	bool copy_blocked_pet_buffs = false;
+	uint16 setting_type = UINT16_MAX;
 
 	for (int i = 0; i < options.size(); i++) {
-		if (sep->arg[3] == options[i]) {
-			setting_type = Bot::GetBotSpellCategoryIDByShortName(sep->arg[3]);
-			valid_option = true;
-			break;
+		if (option_arg == options[i]) {
+			if (option_arg == "all") {
+				copy_all = true;
+				valid_option = true;
+
+				break;
+			}
+			else if (option_arg == "misc") {
+				copy_misc = true;
+				valid_option = true;
+
+				break;
+			}
+			else if (option_arg == "spellsettings") {
+				copy_spell_settings = true;
+				valid_option = true;
+
+				break;
+			}
+			else if (option_arg == "spelltypesettings") {
+				copy_spell_type_settings = true;
+				valid_option = true;
+
+				break;
+			}
+			else if (option_arg == "blockedbuffs") {
+				copy_blocked_buffs = true;
+				valid_option = true;
+
+				break;
+			}
+			else if (option_arg == "blockedpetbuffs") {
+				copy_blocked_pet_buffs = true;
+				valid_option = true;
+
+				break;
+			}
+			else {
+				setting_type = Bot::GetBotSpellCategoryIDByShortName(option_arg);
+
+				if (setting_type != UINT16_MAX) {
+					valid_option = true;
+
+					break;
+				}
+			}
 		}
 	}
 
@@ -226,125 +236,18 @@ void bot_command_copy_settings(Client* c, const Seperator* sep)
 		return;
 	}
 
-	std::string output = "";
+	int ab_arg = 4;
+	std::string spell_type_arg = sep->arg[ab_arg];
+	uint16 spell_type = UINT16_MAX;
 
-	if (setting_type != UINT16_MAX) {
-		if (spell_type != UINT16_MAX) {
-			from->CopySettings(to, setting_type, spell_type);
-		}
-		else {
-			for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-				from->CopySettings(to, setting_type, i);
-			}
-		}
+	if (sep->IsNumber(ab_arg)) {
+		spell_type = atoi(sep->arg[ab_arg]);
 
-		output = Bot::GetBotSpellCategoryName(setting_type);
-	}
-	else {
-		if (!strcasecmp(sep->arg[3], "misc")) {
-			from->CopySettings(to, BotSettingCategories::BaseSetting);
-			output = "Miscellaneous";
-		}
-		else if (!strcasecmp(sep->arg[3], "spellsettings")) {
-			from->CopyBotSpellSettings(to);
-			output = "^spellsettings";
-		}
-		else if (!strcasecmp(sep->arg[3], "spelltypesettings")) {
-			if (spell_type != UINT16_MAX) {
-				from->CopySettings(to, BotSettingCategories::SpellHold, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellDelay, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellMinThreshold, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellMaxThreshold, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeAggroCheck, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeResistLimit, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeMinManaPct, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeMaxManaPct, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeMinHPPct, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeMaxHPPct, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeIdlePriority, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeEngagedPriority, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypePursuePriority, spell_type);				
-				from->CopySettings(to, BotSettingCategories::SpellTypeAEOrGroupTargetCount, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeAnnounceCast, spell_type);
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					from->CopySettings(to, BotSettingCategories::SpellHold, i);
-					from->CopySettings(to, BotSettingCategories::SpellDelay, i);
-					from->CopySettings(to, BotSettingCategories::SpellMinThreshold, i);
-					from->CopySettings(to, BotSettingCategories::SpellMaxThreshold, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeAggroCheck, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeResistLimit, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeMinManaPct, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeMaxManaPct, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeMinHPPct, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeMaxHPPct, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeIdlePriority, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeEngagedPriority, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypePursuePriority, i);					
-					from->CopySettings(to, BotSettingCategories::SpellTypeAEOrGroupTargetCount, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeAnnounceCast, i);
-				}
-			}
-
-			output = "spell type";
-		}
-		else if (!strcasecmp(sep->arg[3], "blockedbuffs")) {
-			from->CopyBotBlockedBuffs(to);
-		}
-		else if (!strcasecmp(sep->arg[3], "blockedpetbuffs")) {
-			from->CopyBotBlockedPetBuffs(to);
-		}
-		else if (!strcasecmp(sep->arg[3], "all")) {
-			from->CopySettings(to, BotSettingCategories::BaseSetting);
-
-			if (spell_type != UINT16_MAX) {
-				from->CopySettings(to, BotSettingCategories::SpellHold, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellDelay, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellMinThreshold, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellMaxThreshold, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeAggroCheck, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeResistLimit, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeMinManaPct, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeMaxManaPct, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeMinHPPct, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeMaxHPPct, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeIdlePriority, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeEngagedPriority, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypePursuePriority, spell_type);				
-				from->CopySettings(to, BotSettingCategories::SpellTypeAEOrGroupTargetCount, spell_type);
-				from->CopySettings(to, BotSettingCategories::SpellTypeAnnounceCast, spell_type);
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					from->CopySettings(to, BotSettingCategories::SpellHold, i);
-					from->CopySettings(to, BotSettingCategories::SpellDelay, i);
-					from->CopySettings(to, BotSettingCategories::SpellMinThreshold, i);
-					from->CopySettings(to, BotSettingCategories::SpellMaxThreshold, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeAggroCheck, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeResistLimit, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeMinManaPct, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeMaxManaPct, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeMinHPPct, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeMaxHPPct, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeIdlePriority, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeEngagedPriority, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypePursuePriority, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeAEOrGroupTargetCount, i);
-					from->CopySettings(to, BotSettingCategories::SpellTypeAnnounceCast, i);
-				}
-			}
-
-			from->CopyBotSpellSettings(to);
-			from->CopyBotBlockedBuffs(to);
-			from->CopyBotBlockedPetBuffs(to);
-			output = "spell type";
-		}
-		else {
+		if (!EQ::ValueWithin(spell_type, BotSpellTypes::START, BotSpellTypes::END)) {
 			c->Message(
 				Chat::Yellow,
 				fmt::format(
-					"Incorrect argument, use {} for information regarding this command.",
+					"You must choose a valid spell type. Use {} for information regarding this command.",
 					Saylink::Silent(
 						fmt::format("{} help", sep->arg[0])
 					)
@@ -353,6 +256,101 @@ void bot_command_copy_settings(Client* c, const Seperator* sep)
 
 			return;
 		}
+
+		++ab_arg;
+	}
+	else if (!spell_type_arg.empty()) {
+		if (Bot::GetSpellTypeIDByShortName(spell_type_arg) != UINT16_MAX) {
+			spell_type = Bot::GetSpellTypeIDByShortName(spell_type_arg);
+			++ab_arg;
+		}
+		else {
+			if (
+				!copy_all &&
+				!copy_misc &&
+				!copy_spell_settings &&
+				!copy_blocked_buffs &&
+				!copy_blocked_pet_buffs
+			) {
+				c->Message(Chat::Yellow, "If you are trying to specify a spell type, you must enter a valid spell type. Otherwise you can ignore this message.");
+			}
+		}
+	}
+
+	std::string output = "";
+
+	if (copy_all) {
+		for (uint16 i = BotBaseSettings::START; i <= BotBaseSettings::END; ++i) {
+			to->SetBotBaseSetting(i, from->GetBotBaseSetting(i));
+		}
+
+		for (uint16 i = BotSettingCategories::START_NO_BASE; i <= BotSettingCategories::END; ++i) {
+			for (uint16 x = BotSpellTypes::START; x <= BotSpellTypes::END; ++x) {
+				to->SetBotSetting(i, x, from->GetSetting(i, x));
+			}
+		}
+
+		from->CopyBotSpellSettings(to);
+		from->CopyBotBlockedBuffs(to);
+		from->CopyBotBlockedPetBuffs(to);
+		output = "settings were";
+	}
+	else if (copy_misc) {
+		for (uint16 i = BotBaseSettings::START; i <= BotBaseSettings::END; ++i) {
+			to->SetBotBaseSetting(i, from->GetBotBaseSetting(i));
+			output = "miscellaneous settings were";
+		}
+	}
+	else if (copy_spell_settings) {
+		from->ResetBotSpellSettings();
+		output = "^spellsettings were";
+	}
+	else if (copy_spell_type_settings) {
+		if (spell_type != UINT16_MAX) {
+			for (uint16 i = BotSettingCategories::START_NO_BASE; i <= BotSettingCategories::END; ++i) {
+				to->SetBotSetting(i, spell_type, from->GetSetting(i, spell_type));
+			}
+
+			output = fmt::format(
+				"[{}] settings were",
+				Bot::GetSpellTypeNameByID(spell_type)
+			);
+		}
+		else {
+			for (uint16 i = BotSettingCategories::START_NO_BASE; i <= BotSettingCategories::END; ++i) {
+				for (uint16 x = BotSpellTypes::START; x <= BotSpellTypes::END; ++x) {
+					to->SetBotSetting(i, x, from->GetSetting(i, x));
+				}
+			}
+
+			output = "spell type settings were";
+		}
+	}
+	else if (copy_blocked_buffs) {
+		from->CopyBotBlockedBuffs(to);
+	}
+	else if (copy_blocked_pet_buffs) {
+		from->CopyBotBlockedPetBuffs(to);
+	}
+	else if (setting_type != UINT16_MAX) {
+		if (spell_type != UINT16_MAX) {
+			to->SetBotSetting(setting_type, spell_type, from->GetSetting(setting_type, spell_type));
+			output = fmt::format(
+				"[{}] {} were",
+				Bot::GetSpellTypeNameByID(spell_type),
+				Bot::GetBotSpellCategoryName(Bot::GetBotSpellCategoryIDByShortName(option_arg))
+			);
+		}
+		else {
+			for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
+				to->SetBotSetting(setting_type, i, from->GetSetting(setting_type, i));
+			}
+
+			output = fmt::format(
+				"{} settings for all spell types",
+				Bot::GetBotSpellCategoryName(Bot::GetBotSpellCategoryIDByShortName(option_arg))
+			);
+		}
 	}
 
 	to->Save();
@@ -360,15 +358,8 @@ void bot_command_copy_settings(Client* c, const Seperator* sep)
 	c->Message(
 		Chat::Green,
 		fmt::format(
-			"{}'s{}{} settings were copied to {}.",
+			"{}'s {} copied to {}.",
 			from->GetCleanName(),
-			(
-				spell_type != UINT16_MAX ?
-				fmt::format(" [{}] ",
-					Bot::GetSpellTypeNameByID(spell_type)
-				)
-				: " "
-			),
 			output,
 			to->GetCleanName()
 		).c_str()

--- a/zone/bot_commands/default_settings.cpp
+++ b/zone/bot_commands/default_settings.cpp
@@ -11,7 +11,7 @@ void bot_command_default_settings(Client* c, const Seperator* sep)
 	if (helper_is_help_or_usage(sep->arg[1])) {
 		BotCommandHelpParams p;
 
-		p.description = { "Restores a bot's setting(s) to defaults" };
+		p.description = { "Restores a bot's setting(s) to defaults." };
 		p.notes = { "- You can put a spell type ID or shortname after any option except [all], [misc] and [spellsettings] to restore that specifc spell type only"};
 		p.example_format = { fmt::format("{} [option] [optional: spelltype id/short name] [actionable]", sep->arg[0]) };
 		p.examples_one =
@@ -38,7 +38,7 @@ void bot_command_default_settings(Client* c, const Seperator* sep)
 			)
 		};
 		p.actionables = { "target, byname, ownergroup, ownerraid, targetgroup, namesgroup, healrotationtargets, mmr, byclass, byrace, spawned" };
-		p.options = { "all, misc, spellsettings, spelltypesettings, spellholds, spelldelays, spellminthresholds, spellmaxthresholds, spellminmanapct, spellmaxmanapct, spellminhppct, spellmaxhppct, spellidlepriority, spellengagedpriority, spellpursuepriority, spellaggrocheck, spelltargetcounts, spellresistlimits, spellannouncecasts" };
+		p.options = { "all, misc, spellsettings, spelltypesettings, spellholds, spelldelays, spellminthresholds, spellmaxthresholds, spellresistlimits, spellaggrocheck, spellminmanapct, spellmaxmanapct, spellminhppct, spellmaxhppct, spellidlepriority, spellengagedpriority, spellpursuepriority, spelltargetcounts, spellannouncecasts" };
 		p.options_one =
 		{
 			"[spellsettings] will restore ^spellsettings options",
@@ -75,12 +75,6 @@ void bot_command_default_settings(Client* c, const Seperator* sep)
 		return;
 	}
 
-	int spell_type_arg_int = 2;
-	std::string spell_type_arg = sep->arg[spell_type_arg_int];
-	int ab_arg = 2;
-	bool valid_option = false;
-	uint16 spell_type = UINT16_MAX;
-	uint16 setting_type = UINT16_MAX;
 	std::vector<std::string> options = 
 	{ 
 		"all",
@@ -91,6 +85,8 @@ void bot_command_default_settings(Client* c, const Seperator* sep)
 		"spelldelays",
 		"spellminthresholds",
 		"spellmaxthresholds",
+		"spellresistlimits",
+		"spellaggrochecks",
 		"spellminmanapct",
 		"spellmaxmanapct",
 		"spellminhppct",
@@ -98,14 +94,76 @@ void bot_command_default_settings(Client* c, const Seperator* sep)
 		"spellidlepriority",
 		"spellengagedpriority",
 		"spellpursuepriority",
-		"spellaggrochecks",
 		"spelltargetcounts",
-		"spellresistlimits",
 		"spellannouncecasts"
 	};
 
-	if (sep->IsNumber(spell_type_arg_int)) {
-		spell_type = atoi(sep->arg[spell_type_arg_int]);
+	std::string option_arg = Strings::ToLower(sep->arg[1]);
+	bool valid_option = false;
+	bool default_all = false;
+	bool default_misc = false;
+	bool default_spell_settings = false;
+	bool default_spell_type_settings = false;
+	uint16 setting_type = UINT16_MAX;
+
+	for (int i = 0; i < options.size(); i++) {
+		if (option_arg == options[i]) {
+			if (option_arg == "all") {
+				default_all = true;
+				valid_option = true;
+
+				break;
+			}
+			else if (option_arg == "misc") {
+				default_misc = true;
+				valid_option = true;
+
+				break;
+			}
+			else if (option_arg == "spellsettings") {
+				default_spell_settings = true;
+				valid_option = true;
+
+				break;
+			}
+			else if (option_arg == "spelltypesettings") {
+				default_spell_type_settings = true;
+				valid_option = true;
+
+				break;
+			}
+			else {
+				setting_type = Bot::GetBotSpellCategoryIDByShortName(option_arg);
+
+				if (setting_type != UINT16_MAX) {
+					valid_option = true;
+
+					break;
+				}
+			}
+		}
+	}
+
+	if (!valid_option) {
+		c->Message(
+			Chat::Yellow,
+			fmt::format(
+				"Incorrect argument, use {} for information regarding this command.",
+				Saylink::Silent(
+					fmt::format("{} help", sep->arg[0])
+				)
+			).c_str()
+		);
+
+		return;
+	}
+
+	int ab_arg = 2;
+	std::string spell_type_arg = sep->arg[ab_arg];
+	uint16 spell_type = UINT16_MAX;
+
+	if (sep->IsNumber(ab_arg)) {
+		spell_type = atoi(sep->arg[ab_arg]);
 
 		if (!EQ::ValueWithin(spell_type, BotSpellTypes::START, BotSpellTypes::END)) {
 			c->Message(
@@ -126,44 +184,13 @@ void bot_command_default_settings(Client* c, const Seperator* sep)
 	else if (!spell_type_arg.empty()) {
 		if (Bot::GetSpellTypeIDByShortName(spell_type_arg) != UINT16_MAX) {
 			spell_type = Bot::GetSpellTypeIDByShortName(spell_type_arg);
+			++ab_arg;
 		}
 		else {
-			c->Message(
-				Chat::Yellow,
-				fmt::format(
-					"You must choose a valid spell type. Use {} for information regarding this command.",
-					Saylink::Silent(
-						fmt::format("{} help", sep->arg[0])
-					)
-				).c_str()
-			);
-
-			return;
+			if (!default_all && !default_misc && !default_spell_settings) {
+				c->Message(Chat::Yellow, "If you are trying to specify a spell type, you must enter a valid spell type. Otherwise you can ignore this message.");
+			}
 		}
-		++ab_arg;
-	}
-
-	for (int i = 0; i < options.size(); i++) {
-		if (sep->arg[1] == options[i]) {
-			setting_type = Bot::GetBotSpellCategoryIDByShortName(sep->arg[1]);
-			valid_option = true;
-
-			break;
-		}
-	}
-
-	if (!valid_option) {
-		c->Message(
-			Chat::Yellow,
-			fmt::format(
-				"Incorrect argument, use {} for information regarding this command.",
-				Saylink::Silent(
-					fmt::format("{} help", sep->arg[0])
-				)
-			).c_str()
-		);
-
-		return;
 	}
 
 	const int ab_mask = ActionableBots::ABM_Type1;
@@ -193,286 +220,72 @@ void bot_command_default_settings(Client* c, const Seperator* sep)
 		}
 
 		bot_stance = my_bot->GetBotStance();
+		
+		if (default_all) {
+			for (uint16 i = BotBaseSettings::START; i <= BotBaseSettings::END; ++i) {
+				my_bot->SetBotBaseSetting(i, my_bot->GetDefaultBotBaseSetting(i, bot_stance));
+			}
+			
+			for (uint16 i = BotSettingCategories::START_NO_BASE; i <= BotSettingCategories::END; ++i) {
+				for (uint16 x = BotSpellTypes::START; x <= BotSpellTypes::END; ++x) {
+					my_bot->SetBotSetting(i, x, my_bot->GetDefaultSetting(i, x, bot_stance));
+				}
+			}
 
-		if (setting_type != UINT16_MAX) {
+			my_bot->ResetBotSpellSettings();
+			my_bot->ClearBotBlockedBuffs();
+			output = "settings were reset";
+		}
+		else if (default_misc) {
+			for (uint16 i = BotBaseSettings::START; i <= BotBaseSettings::END; ++i) {
+				my_bot->SetBotBaseSetting(i, my_bot->GetDefaultBotBaseSetting(i, bot_stance));
+				output = "miscellaneous settings were reset";
+			}
+		}
+		else if (default_spell_settings) {
+			my_bot->ResetBotSpellSettings();
+			output = "^spellsettings were reset";
+		}
+		else if (default_spell_type_settings) {
+			if (spell_type != UINT16_MAX) {
+				for (uint16 i = BotSettingCategories::START_NO_BASE; i <= BotSettingCategories::END; ++i) {
+					my_bot->SetBotSetting(i, spell_type, my_bot->GetDefaultSetting(i, spell_type, bot_stance));
+				}
+
+				output = fmt::format(
+					"[{}] settings were reset",
+					Bot::GetSpellTypeNameByID(spell_type)
+				);
+			}
+			else {
+				for (uint16 i = BotSettingCategories::START_NO_BASE; i <= BotSettingCategories::END; ++i) {
+					for (uint16 x = BotSpellTypes::START; x <= BotSpellTypes::END; ++x) {
+						my_bot->SetBotSetting(i, x, my_bot->GetDefaultSetting(i, x, bot_stance));
+					}
+				}
+				
+				output = "spell type settings were reset";
+			}
+		}
+		else if (setting_type != UINT16_MAX) {
 			if (spell_type != UINT16_MAX) {
 				my_bot->SetBotSetting(setting_type, spell_type, my_bot->GetDefaultSetting(setting_type, spell_type, bot_stance));
+				output = fmt::format(
+					"[{}] {} were reset",
+					Bot::GetSpellTypeNameByID(spell_type),
+					Bot::GetBotSpellCategoryName(Bot::GetBotSpellCategoryIDByShortName(option_arg))
+				);
 			}
 			else {
 				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
 					my_bot->SetBotSetting(setting_type, i, my_bot->GetDefaultSetting(setting_type, i, bot_stance));
 				}
+				
+				output = fmt::format(
+					"{} settings were reset for all spell types",
+					Bot::GetBotSpellCategoryName(Bot::GetBotSpellCategoryIDByShortName(option_arg))
+				);
 			}
-
-			output = (spell_type != UINT16_MAX ? Bot::GetSpellTypeNameByID(spell_type) : "");
-			output += sep->arg[3];
-		}
-		else if (!strcasecmp(sep->arg[1], "misc")) {
-			for (uint16 i = BotBaseSettings::START; i <= BotBaseSettings::END; ++i) {
-				my_bot->SetBotBaseSetting(i, my_bot->GetDefaultBotBaseSetting(i, bot_stance));
-				output = "miscellanous settings";
-			}
-		}
-		else if (!strcasecmp(sep->arg[1], "spellsettings")) {
-			my_bot->ResetBotSpellSettings();
-			output = "^spellsettings";
-		}
-		else if (!strcasecmp(sep->arg[1], "spelltypesettings")) {
-			if (spell_type != UINT16_MAX) {
-				my_bot->SetSpellTypeHold(spell_type, my_bot->GetDefaultSpellTypeHold(spell_type, bot_stance));
-				my_bot->SetSpellTypeDelay(spell_type, my_bot->GetDefaultSpellTypeDelay(spell_type, bot_stance));
-				my_bot->SetSpellTypeMinThreshold(
-					spell_type,
-					my_bot->GetDefaultSpellTypeMinThreshold(spell_type, bot_stance));
-				my_bot->SetSpellTypeMaxThreshold(
-					spell_type,
-					my_bot->GetDefaultSpellTypeMaxThreshold(spell_type, bot_stance));
-				my_bot->SetSpellTypeAggroCheck(spell_type, my_bot->GetDefaultSpellTypeAggroCheck(spell_type, bot_stance));
-				my_bot->SetSpellTypeResistLimit(spell_type, my_bot->GetDefaultSpellTypeResistLimit(spell_type, bot_stance));
-				my_bot->SetSpellTypeMinManaLimit(spell_type, my_bot->GetDefaultSpellTypeMinManaLimit(spell_type, bot_stance));
-				my_bot->SetSpellTypeMaxManaLimit(spell_type, my_bot->GetDefaultSpellTypeMaxManaLimit(spell_type, bot_stance));
-				my_bot->SetSpellTypeMinHPLimit(spell_type, my_bot->GetDefaultSpellTypeMinHPLimit(spell_type, bot_stance));
-				my_bot->SetSpellTypeMaxHPLimit(spell_type, my_bot->GetDefaultSpellTypeMaxHPLimit(spell_type, bot_stance));
-				my_bot->SetSpellTypePriority(spell_type, BotPriorityCategories::Idle, my_bot->GetDefaultSpellTypePriority(spell_type, BotPriorityCategories::Idle, my_bot->GetClass(), bot_stance));
-				my_bot->SetSpellTypePriority(spell_type, BotPriorityCategories::Engaged, my_bot->GetDefaultSpellTypePriority(spell_type, BotPriorityCategories::Engaged, my_bot->GetClass(), bot_stance));
-				my_bot->SetSpellTypePriority(spell_type, BotPriorityCategories::Pursue, my_bot->GetDefaultSpellTypePriority(spell_type, BotPriorityCategories::Pursue, my_bot->GetClass(), bot_stance));
-				my_bot->SetSpellTypeAEOrGroupTargetCount(spell_type, my_bot->GetDefaultSpellTypeAEOrGroupTargetCount(spell_type, bot_stance));
-				my_bot->SetSpellTypeAnnounceCast(spell_type, my_bot->GetDefaultSpellTypeAnnounceCast(spell_type, bot_stance));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					my_bot->SetSpellTypeHold(i, my_bot->GetDefaultSpellTypeHold(i, bot_stance));
-					my_bot->SetSpellTypeDelay(i, my_bot->GetDefaultSpellTypeDelay(i, bot_stance));
-					my_bot->SetSpellTypeMinThreshold(i, my_bot->GetDefaultSpellTypeMinThreshold(i, bot_stance));
-					my_bot->SetSpellTypeMaxThreshold(i, my_bot->GetDefaultSpellTypeMaxThreshold(i, bot_stance));
-					my_bot->SetSpellTypeAggroCheck(i, my_bot->GetDefaultSpellTypeAggroCheck(i, bot_stance));
-					my_bot->SetSpellTypeResistLimit(i, my_bot->GetDefaultSpellTypeResistLimit(i, bot_stance));
-					my_bot->SetSpellTypeMinManaLimit(i, my_bot->GetDefaultSpellTypeMinManaLimit(i, bot_stance));
-					my_bot->SetSpellTypeMaxManaLimit(i, my_bot->GetDefaultSpellTypeMaxManaLimit(i, bot_stance));
-					my_bot->SetSpellTypeMinHPLimit(i, my_bot->GetDefaultSpellTypeMinHPLimit(i, bot_stance));
-					my_bot->SetSpellTypeMaxHPLimit(i, my_bot->GetDefaultSpellTypeMaxHPLimit(i, bot_stance));
-					my_bot->SetSpellTypePriority(i, BotPriorityCategories::Idle, my_bot->GetDefaultSpellTypePriority(i, BotPriorityCategories::Idle, my_bot->GetClass(), bot_stance));
-					my_bot->SetSpellTypePriority(i, BotPriorityCategories::Engaged, my_bot->GetDefaultSpellTypePriority(i, BotPriorityCategories::Engaged, my_bot->GetClass(), bot_stance));
-					my_bot->SetSpellTypePriority(i, BotPriorityCategories::Pursue, my_bot->GetDefaultSpellTypePriority(i, BotPriorityCategories::Pursue, my_bot->GetClass(), bot_stance));
-					my_bot->SetSpellTypeAEOrGroupTargetCount(i, my_bot->GetDefaultSpellTypeAEOrGroupTargetCount(i, bot_stance));
-					my_bot->SetSpellTypeAnnounceCast(i, my_bot->GetDefaultSpellTypeAnnounceCast(i, bot_stance));
-				}
-			}
-
-			output = "spell type settings";
-		}
-		else if (!strcasecmp(sep->arg[1], "all")) {
-			for (uint16 i = BotBaseSettings::START; i <= BotBaseSettings::END; ++i) {
-				my_bot->SetBotBaseSetting(i, my_bot->GetDefaultBotBaseSetting(i, bot_stance));
-			}
-
-			for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-				my_bot->SetSpellTypeHold(i, my_bot->GetDefaultSpellTypeHold(i, bot_stance));
-				my_bot->SetSpellTypeDelay(i, my_bot->GetDefaultSpellTypeDelay(i, bot_stance));
-				my_bot->SetSpellTypeMinThreshold(i, my_bot->GetDefaultSpellTypeMinThreshold(i, bot_stance));
-				my_bot->SetSpellTypeMaxThreshold(i, my_bot->GetDefaultSpellTypeMaxThreshold(i, bot_stance));
-				my_bot->SetSpellTypeAggroCheck(i, my_bot->GetDefaultSpellTypeAggroCheck(i, bot_stance));
-				my_bot->SetSpellTypeResistLimit(i, my_bot->GetDefaultSpellTypeResistLimit(i, bot_stance));
-				my_bot->SetSpellTypeMinManaLimit(i, my_bot->GetDefaultSpellTypeMinManaLimit(i, bot_stance));
-				my_bot->SetSpellTypeMaxManaLimit(i, my_bot->GetDefaultSpellTypeMaxManaLimit(i, bot_stance));
-				my_bot->SetSpellTypeMinHPLimit(i, my_bot->GetDefaultSpellTypeMinHPLimit(i, bot_stance));
-				my_bot->SetSpellTypeMaxHPLimit(i, my_bot->GetDefaultSpellTypeMaxHPLimit(i, bot_stance));
-				my_bot->SetSpellTypePriority(i, BotPriorityCategories::Idle, my_bot->GetDefaultSpellTypePriority(i, BotPriorityCategories::Idle, my_bot->GetClass(), bot_stance));
-				my_bot->SetSpellTypePriority(i, BotPriorityCategories::Engaged, my_bot->GetDefaultSpellTypePriority(i, BotPriorityCategories::Engaged, my_bot->GetClass(), bot_stance));
-				my_bot->SetSpellTypePriority(i, BotPriorityCategories::Pursue, my_bot->GetDefaultSpellTypePriority(i, BotPriorityCategories::Pursue, my_bot->GetClass(), bot_stance));
-				my_bot->SetSpellTypeAEOrGroupTargetCount(i, my_bot->GetDefaultSpellTypeAEOrGroupTargetCount(i, bot_stance));
-				my_bot->SetSpellTypeAnnounceCast(i, my_bot->GetDefaultSpellTypeAnnounceCast(i, bot_stance));
-			};
-
-			my_bot->ResetBotSpellSettings();
-			my_bot->ClearBotBlockedBuffs();
-
-			output = "settings";
-
-		}
-		else if (!strcasecmp(sep->arg[1], "holds")) {
-			if (spell_type != UINT16_MAX) {
-				my_bot->SetSpellTypeHold(spell_type, my_bot->GetDefaultSpellTypeHold(spell_type, bot_stance));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					my_bot->SetSpellTypeHold(i, my_bot->GetDefaultSpellTypeHold(i, bot_stance));
-				}
-			}
-
-			output = "hold settings";
-		}
-		else if (!strcasecmp(sep->arg[1], "delays")) {
-			if (spell_type != UINT16_MAX) {
-				my_bot->SetSpellTypeDelay(spell_type, my_bot->GetDefaultSpellTypeDelay(spell_type, bot_stance));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					my_bot->SetSpellTypeDelay(i, my_bot->GetDefaultSpellTypeDelay(i, bot_stance));
-				}
-			}
-
-			output = "delay settings";
-		}
-		else if (!strcasecmp(sep->arg[1], "minthresholds")) {
-			if (spell_type != UINT16_MAX) {
-				my_bot->SetSpellTypeMinThreshold(
-					spell_type,
-					my_bot->GetDefaultSpellTypeMinThreshold(spell_type, bot_stance));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					my_bot->SetSpellTypeMinThreshold(i, my_bot->GetDefaultSpellTypeMinThreshold(i, bot_stance));
-				}
-			}
-
-			output = "minimum threshold settings";
-		}
-		else if (!strcasecmp(sep->arg[1], "maxthresholds")) {
-			if (spell_type != UINT16_MAX) {
-				my_bot->SetSpellTypeMaxThreshold(
-					spell_type,
-					my_bot->GetDefaultSpellTypeMaxThreshold(spell_type, bot_stance));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					my_bot->SetSpellTypeMaxThreshold(i, my_bot->GetDefaultSpellTypeMaxThreshold(i, bot_stance));
-				}
-			}
-
-			output = "maximum threshold settings";
-		}
-		else if (!strcasecmp(sep->arg[1], "aggrochecks")) {
-			if (spell_type != UINT16_MAX) {
-				my_bot->SetSpellTypeAggroCheck(spell_type, my_bot->GetDefaultSpellTypeAggroCheck(spell_type, bot_stance));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					my_bot->SetSpellTypeAggroCheck(i, my_bot->GetDefaultSpellTypeAggroCheck(i, bot_stance));
-				}
-			}
-
-			output = "aggro check settings";
-		}
-		else if (!strcasecmp(sep->arg[1], "resist limit")) {
-			if (spell_type != UINT16_MAX) {
-				my_bot->SetSpellTypeAEOrGroupTargetCount(spell_type, my_bot->GetDefaultSpellTypeAEOrGroupTargetCount(spell_type, bot_stance));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					my_bot->SetSpellTypeAEOrGroupTargetCount(i, my_bot->GetDefaultSpellTypeAEOrGroupTargetCount(i, bot_stance));
-				}
-			}
-
-			output = "resist limit settings";
-		}
-		else if (!strcasecmp(sep->arg[1], "minmanapct")) {
-			if (spell_type != UINT16_MAX) {
-				my_bot->SetSpellTypeMinManaLimit(spell_type, my_bot->GetDefaultSpellTypeMinManaLimit(spell_type, bot_stance));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					my_bot->SetSpellTypeMinManaLimit(i, my_bot->GetDefaultSpellTypeMinManaLimit(i, bot_stance));
-				}
-			}
-
-			output = "min mana settings";
-		}
-		else if (!strcasecmp(sep->arg[1], "maxmanapct")) {
-			if (spell_type != UINT16_MAX) {
-				my_bot->SetSpellTypeMaxManaLimit(spell_type, my_bot->GetDefaultSpellTypeMaxManaLimit(spell_type, bot_stance));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					my_bot->SetSpellTypeMaxManaLimit(i, my_bot->GetDefaultSpellTypeMaxManaLimit(i, bot_stance));
-				}
-			}
-
-			output = "max mana settings";
-		}
-		else if (!strcasecmp(sep->arg[1], "minhppct")) {
-			if (spell_type != UINT16_MAX) {
-				my_bot->SetSpellTypeMinHPLimit(spell_type, my_bot->GetDefaultSpellTypeMinHPLimit(spell_type, bot_stance));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					my_bot->SetSpellTypeMinHPLimit(i, my_bot->GetDefaultSpellTypeMinHPLimit(i, bot_stance));	
-				}
-			}
-
-			output = "min hp settings";
-		}
-		else if (!strcasecmp(sep->arg[1], "maxhppct")) {
-			if (spell_type != UINT16_MAX) {
-				my_bot->SetSpellTypeMaxHPLimit(spell_type, my_bot->GetDefaultSpellTypeMaxHPLimit(spell_type, bot_stance));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					my_bot->SetSpellTypeMaxHPLimit(i, my_bot->GetDefaultSpellTypeMaxHPLimit(i, bot_stance));
-				}
-			}
-
-			output = "max hp settings";
-		}
-		else if (!strcasecmp(sep->arg[1], "idlepriority")) {
-			if (spell_type != UINT16_MAX) {
-				my_bot->SetSpellTypePriority(spell_type, BotPriorityCategories::Idle, my_bot->GetDefaultSpellTypePriority(spell_type, BotPriorityCategories::Idle, my_bot->GetClass(), bot_stance));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					my_bot->SetSpellTypePriority(i, BotPriorityCategories::Idle, my_bot->GetDefaultSpellTypePriority(i, BotPriorityCategories::Idle, my_bot->GetClass(), bot_stance));
-				}
-			}
-
-			output = "idle priority settings";
-		}
-		else if (!strcasecmp(sep->arg[1], "engagedpriority")) {
-			if (spell_type != UINT16_MAX) {
-				my_bot->SetSpellTypePriority(spell_type, BotPriorityCategories::Engaged, my_bot->GetDefaultSpellTypePriority(spell_type, BotPriorityCategories::Engaged, my_bot->GetClass(), bot_stance));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					my_bot->SetSpellTypePriority(i, BotPriorityCategories::Engaged, my_bot->GetDefaultSpellTypePriority(i, BotPriorityCategories::Engaged, my_bot->GetClass(), bot_stance));
-				}
-			}
-
-			output = "engaged priority settings";
-		}
-		else if (!strcasecmp(sep->arg[1], "pursuepriority")) {
-			if (spell_type != UINT16_MAX) {
-				my_bot->SetSpellTypePriority(spell_type, BotPriorityCategories::Pursue, my_bot->GetDefaultSpellTypePriority(spell_type, BotPriorityCategories::Pursue, my_bot->GetClass(), bot_stance));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					my_bot->SetSpellTypePriority(i, BotPriorityCategories::Pursue, my_bot->GetDefaultSpellTypePriority(i, BotPriorityCategories::Pursue, my_bot->GetClass(), bot_stance));
-				}
-			}
-
-			output = "pursue priority settings";
-		}
-		else if (!strcasecmp(sep->arg[1], "targetcounts")) {
-			if (spell_type != UINT16_MAX) {
-				my_bot->SetSpellTypeAEOrGroupTargetCount(spell_type, my_bot->GetDefaultSpellTypeAEOrGroupTargetCount(spell_type, bot_stance));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					my_bot->SetSpellTypeAEOrGroupTargetCount(i, my_bot->GetDefaultSpellTypeAEOrGroupTargetCount(i, bot_stance));
-				}
-			}
-
-			output = "target count settings";
-		}
-		else if (!strcasecmp(sep->arg[1], "announcecast")) {
-			if (spell_type != UINT16_MAX) {
-				my_bot->SetSpellTypeAEOrGroupTargetCount(spell_type, my_bot->GetDefaultSpellTypeAEOrGroupTargetCount(spell_type, bot_stance));
-			}
-			else {
-				for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; ++i) {
-					my_bot->SetSpellTypeAEOrGroupTargetCount(i, my_bot->GetDefaultSpellTypeAEOrGroupTargetCount(i, bot_stance));
-				}
-			}
-
-			output = "announce cast settings";
 		}
 
 		my_bot->Save();
@@ -483,15 +296,8 @@ void bot_command_default_settings(Client* c, const Seperator* sep)
 		c->Message(
 			Chat::Green,
 			fmt::format(
-				"{} says, '{}{} were restored.'",				
+				"{} says, 'My {}.'",
 				first_found->GetCleanName(),
-				(
-					spell_type != UINT16_MAX ?
-					fmt::format("My [{}] ",
-						Bot::GetSpellTypeNameByID(spell_type)
-					)
-					: "My "
-				),
 				output
 			).c_str()
 		);
@@ -500,15 +306,8 @@ void bot_command_default_settings(Client* c, const Seperator* sep)
 		c->Message(
 			Chat::Green,
 			fmt::format(
-				"{} of your bot's{}{} were restored.",
+				"{} of your bots' {}.",
 				success_count,
-				(
-					spell_type != UINT16_MAX ?
-					fmt::format(" [{}] ",
-						Bot::GetSpellTypeNameByID(spell_type)
-					)
-					: " "
-				),
 				output
 			).c_str()
 		);

--- a/zone/bot_commands/discipline.cpp
+++ b/zone/bot_commands/discipline.cpp
@@ -209,10 +209,6 @@ void bot_command_discipline(Client* c, const Seperator* sep)
 				continue;
 			}
 
-			if (spell.buff_duration_formula != 0 && spell.target_type == ST_Self && bot_iter->HasDiscBuff()) {
-				continue;
-			}
-
 			if (!tar || (spell.target_type == ST_Self && tar != bot_iter)) {
 				tar = bot_iter;
 			}
@@ -231,7 +227,7 @@ void bot_command_discipline(Client* c, const Seperator* sep)
 	}
 
 	if (!is_success) {
-		c->Message(Chat::Yellow, "No bots were selected.");
+		c->Message(Chat::Yellow, "No bots were capable of doing that. This could be because they don't have the ability or things like Line of Sight, range, endurance, etc.");
 	}
 	else {
 		if (aggressive || defensive) {

--- a/zone/bot_commands/distance_ranged.cpp
+++ b/zone/bot_commands/distance_ranged.cpp
@@ -16,7 +16,7 @@ void bot_command_distance_ranged(Client* c, const Seperator* sep)
 		{ 
 			"- Bots will stay between half the value of the setting and the current value. IE, if set to 60, bots will stay between 30 and 60.",
 			"- Casters will never go closer than their maximum melee range.",
-			"- Throwing bots will never get closer than the minimum value for ranged to work, or beyond the range of their items."
+			"- Archery & Throwing bots will never get closer than the minimum value for ranged to work, or beyond the range of their items."
 		};
 		p.example_format = { fmt::format("{} [value] [actionable]", sep->arg[0]) };
 		p.examples_one = {

--- a/zone/bot_commands/max_melee_range.cpp
+++ b/zone/bot_commands/max_melee_range.cpp
@@ -12,6 +12,12 @@ void bot_command_max_melee_range(Client* c, const Seperator* sep)
 		BotCommandHelpParams p;
 		
 		p.description = { "Toggles whether or not bots will stay at max melee range during combat."};
+		p.notes = {
+			fmt::format(
+				"- Bots {} use special abilities when set to max melee range (taunt, kick, bash, etc).",
+				RuleB(Bots, DisableSpecialAbilitiesAtMaxMelee) ? "will not" : "will"
+			)
+		};
 		p.example_format ={ fmt::format("{} [value] [actionable]", sep->arg[0]) };
 		p.examples_one =
 		{

--- a/zone/bot_commands/pet.cpp
+++ b/zone/bot_commands/pet.cpp
@@ -106,6 +106,12 @@ void bot_command_pet_set_type(Client *c, const Seperator *sep)
 		BotCommandHelpParams p;
 
 		p.description = { "Allows you to change the type of pet Magician bots will cast." };
+		p.notes = {
+			fmt::format(
+				"- Epic pets are currently {} on this server.",
+				RuleB(Bots, AllowMagicianEpicPet) ? "allowed" : "not allowed"
+			)
+		};
 		p.example_format = { fmt::format("{} [current | water | fire | air | earth | monster | epic] [actionable, default: target]", sep->arg[0]) };
 		p.examples_one =
 		{

--- a/zone/bot_commands/taunt.cpp
+++ b/zone/bot_commands/taunt.cpp
@@ -12,6 +12,7 @@ void bot_command_taunt(Client* c, const Seperator* sep)
 		BotCommandHelpParams p;
 
 		p.description = { "Allows you to turn on/off the taunting state of your bots and/or their pets." };
+		p.notes = { "- If a taunting class is set to Aggressive (5) stance, they will automatically taunt and don't need to have it enabled manually." };
 		p.example_format = { fmt::format("{} [on / off / pet] [optional: pet]  [actionable, default: target]", sep->arg[0]) };
 		p.examples_one =
 		{

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -2249,7 +2249,7 @@ bool BotDatabase::LoadBotSettings(Mob* m)
 		else {
 			LogBotSettings("[{}] says, 'Loading {} [{}], {} [{}] - setting to [{}].",
 				m->GetCleanName(),
-				Bot::GetBotSpellCategoryName(e.setting_type),
+				Bot::GetBotSpellCategoryShortName(e.setting_type),
 				e.setting_type,
 				Bot::GetSpellTypeNameByID(e.setting_id),
 				e.setting_id,
@@ -2312,7 +2312,7 @@ bool BotDatabase::SaveBotSettings(Mob* m)
 					.setting_id					= static_cast<uint16_t>(i),
 					.setting_type				= static_cast<uint8_t>(BotSettingCategories::BaseSetting),
 					.value						= static_cast<int32_t>(m->CastToBot()->GetBotBaseSetting(i)),
-					.category_name				= Bot::GetBotSpellCategoryName(BotSettingCategories::BaseSetting),
+					.category_name				= Bot::GetBotSpellCategoryShortName(BotSettingCategories::BaseSetting),
 					.setting_name				= Bot::GetBotSettingCategoryName(i)
 				};
 
@@ -2332,13 +2332,13 @@ bool BotDatabase::SaveBotSettings(Mob* m)
 						.setting_id				= static_cast<uint16_t>(x),
 						.setting_type			= static_cast<uint8_t>(i),
 						.value					= m->CastToBot()->GetSetting(i, x),
-						.category_name			= Bot::GetBotSpellCategoryName(i),
+						.category_name			= Bot::GetBotSpellCategoryShortName(i),
 						.setting_name			= Bot::GetSpellTypeNameByID(x)
 					};
 
 					v.emplace_back(e);
 
-					LogBotSettings("{} says, 'Saving {} {} [{}] - set to [{}] default [{}].'", m->GetCleanName(), Bot::GetBotSpellCategoryName(i), Bot::GetSpellTypeNameByID(x), x, e.value, m->CastToBot()->GetDefaultSetting(i, x, bot_stance));
+					LogBotSettings("{} says, 'Saving {} {} [{}] - set to [{}] default [{}].'", m->GetCleanName(), Bot::GetBotSpellCategoryShortName(i), Bot::GetSpellTypeNameByID(x), x, e.value, m->CastToBot()->GetDefaultSetting(i, x, bot_stance));
 				}
 			}
 		}
@@ -2354,7 +2354,7 @@ bool BotDatabase::SaveBotSettings(Mob* m)
 						.setting_id				= static_cast<uint16_t>(BotBaseSettings::IllusionBlock),
 						.setting_type			= static_cast<uint8_t>(BotSettingCategories::BaseSetting),
 						.value 					= m->CastToClient()->GetIllusionBlock(),
-						.category_name			= Bot::GetBotSpellCategoryName(BotSettingCategories::BaseSetting),
+						.category_name			= Bot::GetBotSpellCategoryShortName(BotSettingCategories::BaseSetting),
 						.setting_name			= Bot::GetBotSettingCategoryName(BotBaseSettings::IllusionBlock)
 			};
 
@@ -2366,7 +2366,7 @@ bool BotDatabase::SaveBotSettings(Mob* m)
 
 		for (uint16 i = BotSettingCategories::START_CLIENT; i <= BotSettingCategories::END_CLIENT; ++i) {
 			for (uint16 x = BotSpellTypes::START; x <= BotSpellTypes::END; ++x) {
-				LogBotSettings("{} says, 'Checking {} {} [{}] - set to [{}] default [{}].'", m->GetCleanName(), Bot::GetBotSpellCategoryName(i), Bot::GetSpellTypeNameByID(x), x, m->CastToClient()->GetBotSetting(i, x), m->CastToClient()->GetDefaultBotSettings(i, x));
+				LogBotSettings("{} says, 'Checking {} {} [{}] - set to [{}] default [{}].'", m->GetCleanName(), Bot::GetBotSpellCategoryShortName(i), Bot::GetSpellTypeNameByID(x), x, m->CastToClient()->GetBotSetting(i, x), m->CastToClient()->GetDefaultBotSettings(i, x));
 				if (m->CastToClient()->GetBotSetting(i, x) != m->CastToClient()->GetDefaultBotSettings(i, x)) {
 					auto e = BotSettingsRepository::BotSettings{
 						.character_id			= character_id,
@@ -2375,13 +2375,13 @@ bool BotDatabase::SaveBotSettings(Mob* m)
 						.setting_id				= static_cast<uint16_t>(x),
 						.setting_type			= static_cast<uint8_t>(i),
 						.value					= m->CastToClient()->GetBotSetting(i, x),
-						.category_name			= Bot::GetBotSpellCategoryName(i),
+						.category_name			= Bot::GetBotSpellCategoryShortName(i),
 						.setting_name			= Bot::GetSpellTypeNameByID(x)
 					};
 
 					v.emplace_back(e);
 
-					LogBotSettings("{} says, 'Saving {} {} [{}] - set to [{}] default [{}].'", m->GetCleanName(), Bot::GetBotSpellCategoryName(i), Bot::GetSpellTypeNameByID(x), x, e.value, m->CastToClient()->GetDefaultBotSettings(i, x));
+					LogBotSettings("{} says, 'Saving {} {} [{}] - set to [{}] default [{}].'", m->GetCleanName(), Bot::GetBotSpellCategoryShortName(i), Bot::GetSpellTypeNameByID(x), x, e.value, m->CastToClient()->GetDefaultBotSettings(i, x));
 				}
 			}
 		}


### PR DESCRIPTION
# Description

- Fix ^discipline saying no bots were selected
- Adds more information to certain commands to better explain how they function.
- Rewrote ^copysettings and ^defaultsettings to not be so bloated and accept arguments properly.
- Added long names for setting categories
- Add Spell ID output to ^spells

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Testing

- Verified proper outputs of all commands.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
