### PR TITLE
[Bots] Throw bot pets behind rule for NPCAggro

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -713,6 +713,7 @@ RULE_INT(Aggro, BardAggroCap, 40, "per song bard aggro cap.")
 RULE_INT(Aggro, InitialAggroBonus, 100, "Initial Aggro Bonus, Default: 100")
 RULE_INT(Aggro, InitialPetAggroBonus, 100, "Initial Pet Aggro Bonus, Default 100")
 RULE_STRING(Aggro, ExcludedFleeAllyFactionIDs, "0|5013|5014|5023|5032", "Common Faction IDs that are excluded from faction checks in EntityList::FleeAllyCount")
+RULE_BOOL(Aggro, AggroBotPets, false, "If enabled, NPCs will aggro bot pets")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(TaskSystem)

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1289,6 +1289,7 @@ public:
 	void SetLooting(uint16 val) { entity_id_being_looted = val; }
 
 	bool CheckWillAggro(Mob *mob);
+	bool IsPetAggroExempt(Mob *pet_owner);
 
 	void InstillDoubt(Mob *who);
 	bool Charmed() const { return type_of_pet == petCharmed; }


### PR DESCRIPTION
# Description

- Adds the rule `Aggro, AggroBotPets`.
- Adds bot pets to CheckWillAggro to enable/disable bot pets getting aggro'd by mobs.
- 
## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

- Verified both rules for players and bots functioned properly.
- Tested with GM on vs off and each rule disabled and enabled.
- Aggrod or did not as intended for all scenarios.

Clients tested: 

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
