### PR TITLE
[Bots] Add AEHateLine to HateLine ParentType

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -11519,11 +11519,12 @@ uint16 Bot::GetParentSpellType(uint16 spell_type) {
 		case BotSpellTypes::AELull:
 		case BotSpellTypes::Lull:
 			return BotSpellTypes::Lull;
+		case BotSpellTypes::HateLine:
+		case BotSpellTypes::AEHateLine:
+			return BotSpellTypes::HateLine;
 		case BotSpellTypes::Charm:
 		case BotSpellTypes::Escape:
 		case BotSpellTypes::HateRedux:
-		case BotSpellTypes::HateLine:
-		case BotSpellTypes::AEHateLine:
 		case BotSpellTypes::InCombatBuff:
 		case BotSpellTypes::InCombatBuffSong:
 		case BotSpellTypes::OutOfCombatBuffSong:


### PR DESCRIPTION
# Description

- Adds AE HateLine as a subtype to the HateLine spell type for spell list checks.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- None needed

Clients tested: 

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
