### PR TITLE
[Hotfix] Update pre big bag corpse slot_id's to support big bags

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -6770,6 +6770,25 @@ SET `aliases` =
 WHERE `command` = 'illusionblock'
 AND `aliases` NOT LIKE '%ib%';
 )",
+	},
+	ManifestEntry{
+		.version = 9303,
+		.description = "2025_02_13_corpse_slot_fix.sql",
+		.check = "SELECT * FROM `character_corpse_items` WHERE `equip_slot` BETWEEN 251 AND 350",
+		.condition = "not_empty",
+		.match = "",
+		.sql = R"(
+UPDATE `character_corpse_items` SET `equip_slot` = ((`equip_slot` - 251) + 4010) WHERE `equip_slot` BETWEEN 251 AND 260; -- Bag 1
+UPDATE `character_corpse_items` SET `equip_slot` = ((`equip_slot` - 261) + 4210) WHERE `equip_slot` BETWEEN 261 AND 270; -- Bag 2
+UPDATE `character_corpse_items` SET `equip_slot` = ((`equip_slot` - 271) + 4410) WHERE `equip_slot` BETWEEN 271 AND 280; -- Bag 3
+UPDATE `character_corpse_items` SET `equip_slot` = ((`equip_slot` - 281) + 4610) WHERE `equip_slot` BETWEEN 281 AND 290; -- Bag 4
+UPDATE `character_corpse_items` SET `equip_slot` = ((`equip_slot` - 291) + 4810) WHERE `equip_slot` BETWEEN 291 AND 300; -- Bag 5
+UPDATE `character_corpse_items` SET `equip_slot` = ((`equip_slot` - 301) + 5010) WHERE `equip_slot` BETWEEN 301 AND 310; -- Bag 6
+UPDATE `character_corpse_items` SET `equip_slot` = ((`equip_slot` - 311) + 5210) WHERE `equip_slot` BETWEEN 311 AND 320; -- Bag 7
+UPDATE `character_corpse_items` SET `equip_slot` = ((`equip_slot` - 321) + 5410) WHERE `equip_slot` BETWEEN 321 AND 330; -- Bag 8
+UPDATE `character_corpse_items` SET `equip_slot` = ((`equip_slot` - 331) + 5610) WHERE `equip_slot` BETWEEN 331 AND 340; -- Bag 9
+UPDATE `character_corpse_items` SET `equip_slot` = ((`equip_slot` - 341) + 5810) WHERE `equip_slot` BETWEEN 341 AND 350; -- Bag 10
+)",
 	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9302
+#define CURRENT_BINARY_DATABASE_VERSION 9303
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9054
 
 #endif


### PR DESCRIPTION
# Description

- Corpses were missing from Big Bag slot query update

Fixes https://discord.com/channels/212663220849213441/1339822224533749771

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Tested on corpse pre-update vs post-update to verify proper ID's.
- Looting prior to change would result in empty bags.
- After change, bags are filled with contents.
![pre](https://github.com/user-attachments/assets/424f7aab-7417-491e-a49e-ad66b579077e)
![post](https://github.com/user-attachments/assets/ff3ce6c2-7e34-4955-9970-6c0511fd56b0)

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
