### PR TITLE
[Spells] Add all types to checks for max_targets_allowed rule for AEs

### DIFF
--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -93,7 +93,14 @@ bool IsTargetableAESpell(uint16 spell_id)
 		return false;
 	}
 
-	return spells[spell_id].target_type == ST_AETarget;
+	return (
+		spells[spell_id].target_type == ST_AETarget ||
+		spells[spell_id].target_type == ST_TargetAETap ||
+		spells[spell_id].target_type == ST_AETargetHateList ||
+		spells[spell_id].target_type == ST_TargetAENoPlayersPets ||
+		spells[spell_id].target_type == ST_UndeadAE ||
+		spells[spell_id].target_type == ST_SummonedAE
+	);
 }
 
 bool IsSacrificeSpell(uint16 spell_id)
@@ -675,17 +682,19 @@ bool IsAnyNukeOrStunSpell(uint16 spell_id) {
 }
 
 bool IsAnyAESpell(uint16 spell_id) {
-    return (
-        IsValidSpell(spell_id) &&
-        (
-            IsAEDurationSpell(spell_id) ||
-            IsAESpell(spell_id) ||
-            IsAERainNukeSpell(spell_id) ||
-            IsAERainSpell(spell_id) ||
-            IsPBAESpell(spell_id) ||
-            IsPBAENukeSpell(spell_id)
-        )
-    );
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
+
+	return (
+		IsTargetableAESpell(spell_id) ||
+		IsAESpell(spell_id) ||
+		IsPBAESpell(spell_id) ||
+		IsAEDurationSpell(spell_id) ||
+		IsAERainNukeSpell(spell_id) ||
+		IsAERainSpell(spell_id) ||
+		IsPBAENukeSpell(spell_id)
+	);
 }
 
 bool IsAESpell(uint16 spell_id)
@@ -740,8 +749,8 @@ bool IsPBAESpell(uint16 spell_id)
 
 	if (
 		spell.aoe_range > 0 &&
-		spell.target_type == ST_AECaster
-		) {
+		!IsTargetRequiredForSpell(spell_id)
+	) {
 		return true;
 	}
 

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -1110,7 +1110,7 @@ void EntityList::AESpell(
 	) {
 		max_targets_allowed = RuleI(Spells, TargetedAOEMaxTargets);
 	} else if (
-		IsPBAENukeSpell(spell_id) &&
+		IsPBAESpell(spell_id) &&
 		IsDetrimentalSpell &&
 		!is_npc
 	) {


### PR DESCRIPTION
# Description
- Added all TargetedAE types to IsTargetableAESpell
- Added IsTargetableAESpell to IsAnyAESpell and changed order for earlier escapes
- IsPBAESpell now checks all PBAE types
- The rule Spells, TargetedAOEMaxTargets will now check all Targeted AE types
- The rule Spells, PointBlankAOEMaxTargets will now check all remaining types that can be a PBAE and not only Nuke PBAEs

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Testing

- Validated types received proper count limits based off rules.
- Traced spell logic to ensure the proper types fall in to https://github.com/EQEmu/Server/blob/master/zone/effects.cpp#L1105 which are all based there via the switches in https://github.com/EQEmu/Server/blob/master/zone/spells.cpp#L2152

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
