### PR TITLE
[Bots] Fix AE range calculation

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -9706,6 +9706,7 @@ bool Bot::CastChecks(uint16 spell_id, Mob* tar, uint16 spell_type, bool precheck
 	}
 	//LogBotSpellChecksDetail("{} says, 'Doing CanCastSpellType checks of {} on {}.'", GetCleanName(), GetSpellName(spell_id), tar->GetCleanName());
 	if (!CanCastSpellType(spell_type, spell_id, tar)) {
+		LogBotSpellChecksDetail("{} says, 'Cancelling cast of {} on {} due to CanCastSpellType.'", GetCleanName(), GetSpellName(spell_id), tar->GetCleanName());
 		return false;
 	}
 
@@ -11983,7 +11984,7 @@ bool Bot::HasRequiredLoSForPositioning(Mob* tar) {
 
 bool Bot::HasValidAETarget(Bot* caster, uint16 spell_id, uint16 spell_type, Mob* tar) {
 	int spell_range = caster->GetActSpellRange(spell_id, spells[spell_id].range);
-	int spell_ae_range = caster->GetActSpellRange(spell_id, spells[spell_id].aoe_range);
+	int spell_ae_range = caster->GetAOERange(spell_id);
 	int target_count = 0;
 
 	for (auto& close_mob : caster->m_close_mobs) {
@@ -11994,6 +11995,18 @@ bool Bot::HasValidAETarget(Bot* caster, uint16 spell_id, uint16 spell_type, Mob*
 		}
 
 		switch (spell_type) {
+			case BotSpellTypes::AELull:
+				if (m->GetSpecialAbility(SpecialAbility::PacifyImmunity)) {
+					continue;
+				}
+
+				break;
+			case BotSpellTypes::AEMez:
+				if (m->GetSpecialAbility(SpecialAbility::MesmerizeImmunity)) {
+					continue;
+				}
+
+				break;
 			case BotSpellTypes::AEDispel:
 				if (m->GetSpecialAbility(SpecialAbility::DispellImmunity)) {
 					continue;
@@ -13288,11 +13301,9 @@ bool Bot::IsImmuneToBotSpell(uint16 spell_id, Mob* caster) {
 		(
 			IsEffectInSpell(spell_id, SE_Root) ||
 			IsEffectInSpell(spell_id, SE_MovementSpeed)
-			)
-		) {
-		if (GetSpecialAbility(SpecialAbility::SnareImmunity)) {
-			return true;
-		}
+		)
+	) {
+		return true;
 	}
 
 	if (IsLifetapSpell(spell_id)) {


### PR DESCRIPTION
# Description
- Certain AE types weren't properly calculating their AE range and would base off the actual AE range for targeted types rather than the spells range itself

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Verified bots cast targeted and PB AEs based off the appropriate range.
- Coincides with https://github.com/EQEmu/Server/pull/4682, will undraft when pushed.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
