### PR TITLE
[Commands] Fix #goto not accepting proper heading

### DIFF
--- a/zone/gm_commands/goto.cpp
+++ b/zone/gm_commands/goto.cpp
@@ -57,7 +57,7 @@ void command_goto(Client *c, const Seperator *sep)
 			Strings::ToFloat(sep->arg[1]),
 			Strings::ToFloat(sep->arg[2]),
 			Strings::ToFloat(sep->arg[3]),
-			sep->arg[4] && Strings::IsFloat(sep->arg[4]) ? Strings::ToFloat(sep->arg[1]) : c->GetHeading()
+			sep->arg[4] && Strings::IsFloat(sep->arg[4]) ? Strings::ToFloat(sep->arg[4]) : c->GetHeading()
 		);
 		c->MovePC(
 			zone->GetZoneID(),


### PR DESCRIPTION
# Description

- `#goto` was using the x coordinate as the heading if specified.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Verified proper heading when used via `#goto`

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
