### PR TITLE
[Bots] Prevent medding in combat if any mob has bot targeted

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -2746,10 +2746,25 @@ bool Bot::TryAutoDefend(Client* bot_owner, float leash_distance) {
 
 bool Bot::TryMeditate() {
 	if (!IsMoving() && !spellend_timer.Enabled()) {
-		if (IsEngaged() && HasOrMayGetAggro(IsSitting())) {
-			if (IsSitting()) {
-				Stand();
+		if (IsEngaged()) {
+			if (HasOrMayGetAggro(IsSitting())) {
+				if (IsSitting()) {
+					Stand();
+				}
+
 				return false;
+			}
+
+			for (auto mob : hate_list.GetHateList()) {
+				auto tar = mob->entity_on_hatelist;
+
+				if (tar) {
+					Mob* tar_target = tar->GetTarget();
+
+					if (tar_target && tar_target == this) {
+						return false;
+					}
+				}
 			}
 		}
 
@@ -2758,6 +2773,7 @@ bool Bot::TryMeditate() {
 		if (!(GetPlayerState() & static_cast<uint32>(PlayerState::Aggressive))) {
 			SendAddPlayerState(PlayerState::Aggressive);
 		}
+
 		return true;
 	}
 


### PR DESCRIPTION
# Description

- Previously this only checked the bot's target to med. It will now check the hatelist of the bot to ensure no mobs have the bot targeted before medding.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Verified that bots would not sit if any mob had them targeted if multiple mobs were on the bot's hatelist.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
