### PR TITLE
[Bots] Improve positioning

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -11814,15 +11814,15 @@ void Bot::DoCombatPositioning(
 		}
 		else if (tar->IsRooted() && !IsTaunting()) { // Move non-taunters out of range - Above already checks if bot is targeted, otherwise they would stay
 			if (tar_distance <= melee_distance_max) {
-				if (PlotBotPositionAroundTarget(tar, Goal.x, Goal.y, Goal.z, (melee_distance_max + 1), (melee_distance_max * 2), false, IsTaunting())) {
+				if (PlotBotPositionAroundTarget(tar, Goal.x, Goal.y, Goal.z, (melee_distance_max + 1), (melee_distance_max * 2), GetBehindMob(), false)) {
 					RunToGoalWithJitter(Goal);
 
 					return;
 				}
 			}
 		}
-		else if (IsTaunting() && ((tar_distance < melee_distance_min) || !front_mob)) { // Back up any bots that are too close
-			if (PlotBotPositionAroundTarget(tar, Goal.x, Goal.y, Goal.z, melee_distance_min, melee_distance, false, IsTaunting())) {
+		else if (tar_distance < melee_distance_min || (!front_mob && IsTaunting())) { // Back up any bots that are too close
+			if (PlotBotPositionAroundTarget(tar, Goal.x, Goal.y, Goal.z, melee_distance_min, melee_distance, GetBehindMob(), (IsTaunting() || !GetBehindMob()))) {
 				RunToGoalWithJitter(Goal);
 
 				return;
@@ -11857,8 +11857,8 @@ void Bot::DoCombatPositioning(
 					}
 				}
 			}
-			else if (tar_distance < melee_distance_min || (GetBehindMob() && !behind_mob) || (IsTaunting() && !front_mob)|| !HasRequiredLoSForPositioning(tar)) { // Regular adjustment
-				if (PlotBotPositionAroundTarget(tar, Goal.x, Goal.y, Goal.z, melee_distance_min, melee_distance, GetBehindMob(), IsTaunting())) {
+			else if (tar_distance < melee_distance_min || (GetBehindMob() && !behind_mob) || (IsTaunting() && !front_mob) || !HasRequiredLoSForPositioning(tar)) { // Regular adjustment
+				if (PlotBotPositionAroundTarget(tar, Goal.x, Goal.y, Goal.z, melee_distance_min, melee_distance, GetBehindMob(), (IsTaunting() || !GetBehindMob()))) {
 					RunToGoalWithJitter(Goal);
 
 					return;


### PR DESCRIPTION
# Description

- Prevent bots not set to ^behindmob from finding positions behind their target.
- Backs up a bot if they're too close and have target reflection, not just taunting bots.
- Backs up bots if the target is rooting and they are not taunting to the appropriate position.
- This will particularly help with casters running around.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Verified positioning scenarios when set to behind mob vs not, taunting vs not, rooted with both behind/taunting scenarios and feared.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
