### PR TITLE
[Bots] Fix unresponsive bots in groups upon group wipe

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -3728,7 +3728,7 @@ bool Bot::Spawn(Client* botCharacterOwner) {
 				SetVerifiedRaid(true);
 			}
 		}
-		else if (auto group = entity_list.GetGroupByMob(this)) {
+		else if (auto group = entity_list.GetGroupByMobName(GetName())) {
 			// Safety Check to confirm we have a valid group
 			auto owner = GetBotOwner();
 			if (owner && !group->IsGroupMember(owner->GetCleanName())) {
@@ -3744,7 +3744,7 @@ bool Bot::Spawn(Client* botCharacterOwner) {
 
 		if (RuleB(Bots, RunSpellTypeChecksOnSpawn)) {
 			OwnerMessage("Running SpellType checks. There may be some spells that are mislabeled as incorrect. Use this as a loose guideline.");
-			CheckBotSpells(); //This runs through a serious of checks and outputs any spells that are set to the wrong spell type in the database
+			CheckBotSpells(); //This runs through a series of checks and outputs any spells that are set to the wrong spell type in the database
 		}
 
 		if (IsBotRanged()) {


### PR DESCRIPTION
# Description

- Bots were failing to recall their group after dying due to checking for the group by their pointer vs name on the entity list.

Fixes [bots not answering to commands](https://discord.com/channels/212663220849213441/1342663615085285498)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

https://github.com/user-attachments/assets/1b41ffb6-94fa-49d0-8595-61494cc18e0f

https://github.com/user-attachments/assets/96a2e54c-b086-4b64-8efe-50e4eb686ad0

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
