### PR TITLE
[Pets] Fix renamed pets loading as blank names

### DIFF
--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -165,11 +165,14 @@ void Mob::MakePoweredPet(uint16 spell_id, const char* pettype, int16 petpower,
 	// 4 - Keep DB name
 	// 5 - `s ward
 
-	if (IsClient() && !petname) {
-		const auto vanity_name = CharacterPetNameRepository::FindOne(database, CastToClient()->CharacterID());
-		if (!vanity_name.name.empty()) {
-			petname = vanity_name.name.c_str();
-		}
+	const auto vanity_name = (IsClient() && !petname) ? CharacterPetNameRepository::FindOne(database, CastToClient()->CharacterID()) : CharacterPetNameRepository::CharacterPetName{};
+
+	if (
+		IsClient() &&
+		!petname &&
+		!vanity_name.name.empty()
+	) {
+		petname = vanity_name.name.c_str();
 	}
 
 	if (petname != nullptr) {


### PR DESCRIPTION
# Description
- Custom pet names would appear as blank.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Testing
![pet_naming](https://github.com/user-attachments/assets/5f79471e-ea40-4fbf-8223-e8ceda3d1a91)
### **Before**:
![Before](https://github.com/user-attachments/assets/c3b14010-940a-4ba3-a1c1-fb5502294ced)
### **After**:
![After](https://github.com/user-attachments/assets/e93182fb-1784-48c0-ad57-ba6544297f6a)

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
