### PR TITLE
[Crash] Bot aura crash fix

### DIFF
--- a/zone/aura.cpp
+++ b/zone/aura.cpp
@@ -690,11 +690,15 @@ void Aura::ProcessSpawns()
 			continue;
 		}
 
-		if (!e.second->IsOfClientBot()) {
+		if (!e.second->IsClient()) {
 			continue;
 		}
 
 		auto c = e.second->CastToClient();
+
+		if (!c) {
+			continue;
+		}
 
 		bool spawned = spawned_for.find(c->GetID()) != spawned_for.end();
 		if (ShouldISpawnFor(c)) {

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -3615,6 +3615,7 @@ void Bot::BotPullerProcess(Client* bot_owner, Raid* raid) {
 void Bot::Depop() {
 	WipeHateList();
 	entity_list.RemoveFromHateLists(this);
+	RemoveAllAuras();
 
 	if (HasPet())
 		GetPet()->Depop();


### PR DESCRIPTION
# Description

- Something between the latest release caused this crash to appear, unsure of this exact cause.
- Prevents bots from being sent a spawn packet for Auras.
- Removes the bot's auras on Depop

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Zoning with bots and aura.
- Camping to ensure bot aura fades.
- Made sure bot camp doesn't affect client auras.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
