### PR TITLE
[Bots] Fix buffs not overwriting lesser buffs

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -9766,7 +9766,7 @@ bool Bot::CastChecks(uint16 spell_id, Mob* tar, uint16 spell_type, bool precheck
 			)
 		)
 		&&
-		tar->CanBuffStack(spell_id, GetLevel(), true) < 0
+		tar->CanBuffStack(spell_id, GetLevel(), false) < 0
 	) {
 		LogBotSpellChecksDetail("{} says, 'Cancelling cast of {} on {} due to !CanBuffStack.'", GetCleanName(), GetSpellName(spell_id), tar->GetCleanName());
 		return false;


### PR DESCRIPTION
# Description

- Buffs would not cast if they would overwrite another spell which could limit the buffs a bot or player could receive.

Fixes [Bots not casting higher tier resist buffs when a lower tier resist buff is present](https://discord.com/channels/212663220849213441/1345259057061302366)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Verified buff stacking/overwriting works in and out of combat.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
