### PR TITLE
[Bots] Charmed Pets were breaking Mob respawns

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -3578,8 +3578,16 @@ void Bot::Depop() {
 	entity_list.RemoveFromHateLists(this);
 	RemoveAllAuras();
 
-	if (HasPet())
-		GetPet()->Depop();
+	Mob* bot_pet = GetPet();
+	
+	if (bot_pet) {
+		if (bot_pet->Charmed()) {
+			bot_pet->BuffFadeByEffect(SE_Charm);
+		}
+		else {
+			bot_pet->Depop();
+		}
+	}
 
 	_botOwner = nullptr;
 	_botOwnerCharacterID = 0;


### PR DESCRIPTION
# Description

- When bots would charm a pet, once they zoned or camped the pet would poof and not trigger a respawn so the NPC which was charmed would never respawn until the zone was shut down or server restarted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Verified zoning/camping with charmed pets, normal pets and no pets to verify functionality.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
