### PR TITLE
[Bots] Enraged positioning and cleanup

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -861,8 +861,6 @@ RULE_REAL(Bots, UpperMeleeDistanceMultiplier, 0.55, "Furthest % of the hit box a
 RULE_REAL(Bots, UpperTauntingMeleeDistanceMultiplier, 0.45, "Furthest % of the hit box a taunting melee bot will get from the target. Default 0.45")
 RULE_REAL(Bots, UpperMaxMeleeRangeDistanceMultiplier, 0.95, "Furthest % of the hit box a max melee range melee bot will get from the target. Default 0.95")
 RULE_BOOL(Bots, DisableSpecialAbilitiesAtMaxMelee, true, "If true, when bots are at max melee distance, special abilities including taunt will be disabled. Default True.")
-RULE_BOOL(Bots, TauntingBotsFollowTopHate, true, "True Default. If true, bots that are taunting will attempt to stick with whoever currently is top hate.")
-RULE_INT(Bots, DistanceTauntingBotsStickMainHate, 10, "If TauntingBotsFollowTopHate is enabled, this is the distance bots will try to stick to whoever currently is Top Hate.")
 RULE_INT(Bots, MinJitterTimer, 500, "Minimum ms between bot movement jitter checks.")
 RULE_INT(Bots, MaxJitterTimer, 2500, "Maximum ms between bot movement jitter checks. Set to 0 to disable timer checks.")
 RULE_BOOL(Bots, PreventBotCampOnFD, true, "True Default. If true, players will not be able to camp bots while feign death.")

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -235,7 +235,7 @@ static std::map<uint16, std::string> botSubType_names = {
 struct CombatRangeInput {
 	Mob*                    target;
 	float                   target_distance;
-	uint8                   stop_melee_level;
+	bool                    stop_melee_level;
 	const EQ::ItemInstance* p_item;
 	const EQ::ItemInstance* s_item;
 };


### PR DESCRIPTION
# Description

- Non-taunting melee bots will now properly go behind their target when it is enraged.
- Reduces how often taunting bots adjust their positioning by removing unnecessary rules.
- Cleans up CombatPositioning

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Tested positioning for rooted, feared, taunting, behindmob, ranged, caster, etc.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
