### PR TITLE
[Bots] Prevent bot pets from despawning on #repop

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -3143,20 +3143,23 @@ void EntityList::Depop(bool StartSpawnTimer)
 {
 	for (auto it = npc_list.begin(); it != npc_list.end(); ++it) {
 		NPC *pnpc = it->second;
+
 		if (pnpc) {
 			Mob *own = pnpc->GetOwner();
-			//do not depop player's pets...
-			if (own && own->IsClient())
+			//do not depop player/bot pets...
+			if (own && own->IsOfClientBot()) {
 				continue;
+			}
 
-			if (pnpc->IsHorse())
+			if (pnpc->IsHorse()) {
 				continue;
+			}
 
-			if (pnpc->IsFindable())
+			if (pnpc->IsFindable()) {
 				UpdateFindableNPCState(pnpc, true);
+			}
 
 			pnpc->WipeHateList();
-
 			pnpc->Depop(StartSpawnTimer);
 		}
 	}


### PR DESCRIPTION
# Description

- Prevents bot pets from depopping on #repop

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Verified with `#repop`, `#repop force`, `#reload world_repop` and `#reload_world_repop_timers` to ensure player and bot pets stayed spawned.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
