### PR TITLE
[Bots] Fix Rule ZonesWithSpawnLimits/ZonesWithForcedSpawnLimits errors

### DIFF
--- a/zone/client_bot.cpp
+++ b/zone/client_bot.cpp
@@ -138,7 +138,7 @@ int Client::GetBotSpawnLimit(uint8 class_id) {
 		}
 
 		catch (const std::exception& e) {
-			LogInfo("Invalid entry in Rule VegasScaling:SpecialScalingZones or SpecialScalingZonesVersions: [{}]", e.what());
+			LogInfo("Invalid entry in Rule Bots:ZonesWithSpawnLimits or Bots:ZoneSpawnLimits: [{}]", e.what());
 		}
 	}
 
@@ -161,7 +161,7 @@ int Client::GetBotSpawnLimit(uint8 class_id) {
 		}
 
 		catch (const std::exception& e) {
-			LogInfo("Invalid entry in Rule VegasScaling:SpecialScalingZones or SpecialScalingZonesVersions: [{}]", e.what());
+			LogInfo("Invalid entry in Rule Bots:ZonesWithForcedSpawnLimits or Bots:ZoneForcedSpawnLimits: [{}]", e.what());
 		}
 	}
 

--- a/zone/client_bot.cpp
+++ b/zone/client_bot.cpp
@@ -120,48 +120,46 @@ int Client::GetBotSpawnLimit(uint8 class_id) {
 	}
 
 	const auto& zones_list = Strings::Split(RuleS(Bots, ZonesWithSpawnLimits), ",");
-	const auto& zones_limits_list = Strings::Split(RuleS(Bots, ZoneSpawnLimits), ",");
-	int i = 0;
 
-	for (const auto& result : zones_list) {
-		try {
-			if (
-				std::stoul(result) == zone->GetZoneID() &&
-				std::stoul(zones_limits_list[i]) < bot_spawn_limit
-			) {
-				bot_spawn_limit = std::stoul(zones_limits_list[i]);
+	if (!zones_list.empty()) {
+		auto it = std::find(zones_list.begin(), zones_list.end(), std::to_string(zone->GetZoneID()));
 
-				break;
+		if (it != zones_list.end()) {
+			const auto& zones_limits_list = Strings::Split(RuleS(Bots, ZoneSpawnLimits), ",");
+
+			if (zones_list.size() == zones_limits_list.size()) {
+				try {
+					auto new_limit = std::stoul(zones_limits_list[std::distance(zones_list.begin(), it)]);
+
+					if (new_limit < bot_spawn_limit) {
+						bot_spawn_limit = new_limit;
+					}
+				} catch (const std::exception& e) {
+					LogInfo("Invalid entry in Rule Bots:ZoneSpawnLimits: [{}]", e.what());
+				}
 			}
-
-			++i;
-		}
-
-		catch (const std::exception& e) {
-			LogInfo("Invalid entry in Rule Bots:ZonesWithSpawnLimits or Bots:ZoneSpawnLimits: [{}]", e.what());
 		}
 	}
 
 	const auto& zones_forced_list = Strings::Split(RuleS(Bots, ZonesWithForcedSpawnLimits), ",");
-	const auto& zones_forced_limits_list = Strings::Split(RuleS(Bots, ZoneForcedSpawnLimits), ",");
-	i = 0;
 
-	for (const auto& result : zones_forced_list) {
-		try {
-			if (
-				std::stoul(result) == zone->GetZoneID() &&
-				std::stoul(zones_forced_limits_list[i]) != bot_spawn_limit
-			) {
-				bot_spawn_limit = std::stoul(zones_forced_limits_list[i]);
+	if (!zones_forced_list.empty()) {
+		auto it = std::find(zones_forced_list.begin(), zones_forced_list.end(), std::to_string(zone->GetZoneID()));
 
-				break;
+		if (it != zones_forced_list.end()) {
+			const auto& zones_forced_limits_list = Strings::Split(RuleS(Bots, ZoneForcedSpawnLimits), ",");
+
+			if (zones_forced_list.size() == zones_forced_limits_list.size()) {
+				try {
+					auto new_limit = std::stoul(zones_forced_limits_list[std::distance(zones_forced_list.begin(), it)]);
+
+					if (new_limit != bot_spawn_limit) {
+						bot_spawn_limit = new_limit;
+					}
+				} catch (const std::exception& e) {
+					LogInfo("Invalid entry in Rule Bots:ZoneForcedSpawnLimits: [{}]", e.what());
+				}
 			}
-
-			++i;
-		}
-
-		catch (const std::exception& e) {
-			LogInfo("Invalid entry in Rule Bots:ZonesWithForcedSpawnLimits or Bots:ZoneForcedSpawnLimits: [{}]", e.what());
 		}
 	}
 


### PR DESCRIPTION
# Description

- Oops. Copy/paste of error for wrong rule names.
- Cleans up logic removing false errors and catches.
- `Bots:ZonesWithSpawnLimits` - This is to be used when zones will only allow up to x amount of bots. Example: A player can normally spawn 5 bots but a zone in this rule has a lower limit of up to 3, this rule would override their normal limit if their normal limit is above the listed zone's max in `Bots:ZoneSpawnLimits`.
- `Bots:ZonesWithForcedSpawnLimits` - Zones in this rule will override any spawn limits high or low and force it. If one player can normally spawn 2 and another player can spawn 10 but a zone listed forces a limit of 5, all players will be able to spawn 5. Follows the limits set in `Bots:ZoneForcedSpawnLimits`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- None needed

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
