### PR TITLE
[Bots] Correct ^pull logic and add checks for Enchanter pets

### DIFF
--- a/zone/bot.h
+++ b/zone/bot.h
@@ -232,6 +232,12 @@ static std::map<uint16, std::string> botSubType_names = {
 	{ CommandedSubTypes::Selo,                      "Selo" }
 };
 
+namespace BotAnimEmpathy {
+	constexpr uint8 Guard       		= 1;
+	constexpr uint8 Attack           	= 2;
+	constexpr uint8 BackOff             = 3;
+};
+
 struct CombatRangeInput {
 	Mob*                    target;
 	float                   target_distance;
@@ -804,6 +810,7 @@ public:
 	EQ::ItemInstance* GetBotItem(uint16 slot_id);
 	bool GetSpawnStatus() { return _spawnStatus; }
 	uint8 GetPetChooserID() { return _petChooserID; }
+	bool HasControllablePet(uint8 ranks_required = 0);
 	bool IsBotRanged() { return _botRangedSetting; }
 	bool IsBotCharmer() { return _botCharmer; }
 	bool IsBot() const override { return true; }

--- a/zone/bot_commands/bot.cpp
+++ b/zone/bot_commands/bot.cpp
@@ -1560,8 +1560,11 @@ void bot_command_summon(Client *c, const Seperator *sep)
 			continue;
 		}
 
-		bot_iter->GetPet()->WipeHateList();
-		bot_iter->GetPet()->SetTarget(nullptr);
+		if (bot_iter->HasControllablePet(BotAnimEmpathy::BackOff)) {
+			bot_iter->GetPet()->WipeHateList();
+			bot_iter->GetPet()->SetTarget(nullptr);
+		}
+
 		bot_iter->GetPet()->Teleport(c->GetPosition());
 	}
 

--- a/zone/bot_commands/click_item.cpp
+++ b/zone/bot_commands/click_item.cpp
@@ -50,7 +50,7 @@ void bot_command_click_item(Client* c, const Seperator* sep)
 	Mob* tar = c->GetTarget();
 
 	for (auto my_bot : sbl) {
-		if (my_bot->BotPassiveCheck()) {
+		if (!my_bot->ValidStateCheck(c)) {
 			continue;
 		}
 

--- a/zone/bot_commands/click_item.cpp
+++ b/zone/bot_commands/click_item.cpp
@@ -50,7 +50,7 @@ void bot_command_click_item(Client* c, const Seperator* sep)
 	Mob* tar = c->GetTarget();
 
 	for (auto my_bot : sbl) {
-		if (!my_bot->ValidStateCheck(c)) {
+		if (my_bot->BotPassiveCheck()) {
 			continue;
 		}
 

--- a/zone/bot_commands/pull.cpp
+++ b/zone/bot_commands/pull.cpp
@@ -103,10 +103,6 @@ void bot_command_pull(Client *c, const Seperator *sep)
 			alternate_bot_puller = bot_iter;
 			alternate_puller_found = true;
 		}
-
-		if (backup_puller_found) {
-			break;
-		}
 	}
 
 	bot_puller = backup_bot_puller ? backup_bot_puller : alternate_bot_puller;

--- a/zone/bot_commands/pull.cpp
+++ b/zone/bot_commands/pull.cpp
@@ -5,8 +5,8 @@ void bot_command_pull(Client *c, const Seperator *sep)
 	if (helper_command_alias_fail(c, "bot_command_pull", sep->arg[0], "pull")) {
 		return;
 	}
-	if (helper_is_help_or_usage(sep->arg[1])) {
 
+	if (helper_is_help_or_usage(sep->arg[1])) {
 		c->Message(Chat::White, "usage: <enemy_target> %s ([actionable: target | byname | ownergroup | ownerraid | targetgroup | namesgroup | healrotationtargets | mmr | byclass | byrace | spawned] ([actionable_name]))", sep->arg[0]);
 		return;
 	}
@@ -40,7 +40,7 @@ void bot_command_pull(Client *c, const Seperator *sep)
 
 	if (
 		!target_mob ||
-		target_mob == c ||
+		target_mob->IsOfClientBotMerc() ||
 		!c->IsAttackAllowed(target_mob)
 	) {
 		c->Message(Chat::White, "Your current target is not attackable!");
@@ -55,12 +55,16 @@ void bot_command_pull(Client *c, const Seperator *sep)
 	}
 
 	if (target_mob->IsNPC() && target_mob->GetHateList().size()) {
-
 		c->Message(Chat::White, "Your current target is already engaged!");
+
 		return;
 	}
 
 	Bot* bot_puller = nullptr;
+	Bot* backup_bot_puller = nullptr;
+	Bot* alternate_bot_puller = nullptr;
+	bool backup_puller_found = false;
+	bool alternate_puller_found = false;
 
 	for (auto bot_iter : sbl) {
 		if (!bot_iter->ValidStateCheck(c)) {
@@ -72,71 +76,40 @@ void bot_command_pull(Client *c, const Seperator *sep)
 			case Class::Monk:
 			case Class::Bard:
 			case Class::Ranger:
-				bot_puller = bot_iter;
-				break;
-			case Class::Warrior:
-			case Class::ShadowKnight:
-			case Class::Paladin:
-			case Class::Berserker:
-			case Class::Beastlord:
-				if (!bot_puller) {
+				bot_iter->SetPullFlag();
 
-					bot_puller = bot_iter;
-					continue;
-				}
-
-				switch (bot_puller->GetClass()) {
-					case Class::Druid:
-					case Class::Shaman:
-					case Class::Cleric:
-					case Class::Wizard:
-					case Class::Necromancer:
-					case Class::Magician:
-					case Class::Enchanter:
-						bot_puller = bot_iter;
-					default:
-						continue;
-				}
-
-				continue;
-			case Class::Druid:
-			case Class::Shaman:
-			case Class::Cleric:
-				if (!bot_puller) {
-
-					bot_puller = bot_iter;
-					continue;
-				}
-
-				switch (bot_puller->GetClass()) {
-					case Class::Wizard:
-					case Class::Necromancer:
-					case Class::Magician:
-					case Class::Enchanter:
-						bot_puller = bot_iter;
-					default:
-						continue;
-				}
-
-				continue;
-			case Class::Wizard:
-			case Class::Necromancer:
-			case Class::Magician:
-			case Class::Enchanter:
-				if (!bot_puller) {
-					bot_puller = bot_iter;
-				}
-
-				continue;
+				return;
 			default:
-				continue;
+				break;
 		}
 
+		if (!backup_puller_found) {
+			switch (bot_iter->GetClass()) {
+				case Class::Warrior:
+				case Class::ShadowKnight:
+				case Class::Paladin:
+				case Class::Berserker:
+				case Class::Beastlord:
+					backup_bot_puller = bot_iter;
+					backup_puller_found = true;
 
-		bot_puller = bot_iter;
+					break;
+				default:
+					break;
+			}
+		}
 
-		break;
+		if (!backup_puller_found && !alternate_puller_found) {
+			alternate_bot_puller = bot_iter;
+			alternate_puller_found = true;
+		}
+
+		if (backup_puller_found) {
+			break;
+		}
 	}
+
+	bot_puller = backup_bot_puller ? backup_bot_puller : alternate_bot_puller;
 
 	if (bot_puller) {
 		bot_puller->SetPullFlag();

--- a/zone/bot_commands/release.cpp
+++ b/zone/bot_commands/release.cpp
@@ -17,6 +17,12 @@ void bot_command_release(Client *c, const Seperator *sep)
 	sbl.erase(std::remove(sbl.begin(), sbl.end(), nullptr), sbl.end());
 	for (auto bot_iter : sbl) {
 		bot_iter->WipeHateList();
+
+		if (bot_iter->GetPet() && bot_iter->HasControllablePet(BotAnimEmpathy::BackOff)) {
+			bot_iter->GetPet()->WipeHateList();
+			bot_iter->GetPet()->SetTarget(nullptr);
+		}
+
 		bot_iter->SetPauseAI(false);
 	}
 


### PR DESCRIPTION
# Description

- Removed initial LoS check from bots and rely only on owner when told to ^pull. This prevents bots from getting stuck in a loop if they don't have LoS when trying to initiate the pull.
- Fixed Animation Empathy checks and consolidates.
- Enchanter pets will honor Animation Empathy rules all around.
- Pets will properly guard if allowed when pulling.
- Adds additional checks to ensure pulls go properly and abort properly.
- Uses tiered checks when within range to do the appropriate attack (Archery->Spell AI->Pull Spell [Throw Stone by default])

[Bot Pull Bug](https://discord.com/channels/212663220849213441/1350097470620831794/1355671467404300288)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Verified LoS scenarios and different types of pulling with bots.
- Verified Enchanter pets are only controllable when applicable (proper ranked of Animation Empathy).
- Verified Pet guards properly on pulls and releases guard on return.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
