### PR TITLE
[Bots] Add valid state checks to ^clickitem

### DIFF
--- a/zone/bot_commands/click_item.cpp
+++ b/zone/bot_commands/click_item.cpp
@@ -48,6 +48,7 @@ void bot_command_click_item(Client* c, const Seperator* sep)
 	sbl.erase(std::remove(sbl.begin(), sbl.end(), nullptr), sbl.end());
 
 	Mob* tar = c->GetTarget();
+	bool is_success = false;
 
 	for (auto my_bot : sbl) {
 		if (!my_bot->ValidStateCheck(c)) {
@@ -68,6 +69,11 @@ void bot_command_click_item(Client* c, const Seperator* sep)
 			continue;
 		}
 
+		is_success = true;
 		my_bot->TryItemClick(slot_id);
+	}
+
+	if (!is_success) {
+		c->Message(Chat::Yellow, "None of your bots are capable of doing that currently.");
 	}
 }

--- a/zone/bot_commands/click_item.cpp
+++ b/zone/bot_commands/click_item.cpp
@@ -50,7 +50,7 @@ void bot_command_click_item(Client* c, const Seperator* sep)
 	Mob* tar = c->GetTarget();
 
 	for (auto my_bot : sbl) {
-		if (my_bot->BotPassiveCheck()) {
+		if (!my_bot->ValidStateCheck(c)) {
 			continue;
 		}
 


### PR DESCRIPTION
# Description

- Bots previously weren't checking if they were in a valid state or not before trying to click an item when told (in a death state, held, feared, silenced, in group/raid, etc.)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Same checks as other commands to ensure only eligible bots are selected

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
