### PR TITLE
[Bots] Flag all buffs with SE_DamageShield as Damage Shield

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -9738,7 +9738,7 @@ bool Bot::CastChecks(uint16 spell_id, Mob* tar, uint16 spell_type, bool precheck
 			)
 		)
 		&&
-		tar->CanBuffStack(spell_id, GetLevel(), false) < 0
+		tar->CanBuffStack(spell_id, GetLevel(), true) < 0
 	) {
 		LogBotSpellChecksDetail("{} says, 'Cancelling cast of {} on {} due to !CanBuffStack.'", GetCleanName(), GetSpellName(spell_id), tar->GetCleanName());
 		return false;

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -11842,7 +11842,7 @@ bool Bot::IsValidSpellTypeBySpellID(uint16 spell_type, uint16 spell_id) {
 			return false;
 		case BotSpellTypes::ResistBuffs:
 		case BotSpellTypes::PetResistBuffs:
-			if (IsResistanceBuffSpell(spell_id)) {
+			if (IsResistanceBuffSpell(spell_id) && !IsEffectInSpell(spell_id, SE_DamageShield)) {
 				return true;
 			}
 


### PR DESCRIPTION
# Description

- Certain resist spells have a DS bonus on them and can be casted as a resist rather than a damage shield. This forces anything with a damage shield as a damage shield buff.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Verified previous spells that would show up as a resist buff now show as damage shield.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
