### PR TITLE
[Bots] Prevent non-taunters from potentially fleeing from mob

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -12009,7 +12009,7 @@ bool Bot::DoCombatPositioning(const CombatPositioningInput& input)
 		}
 		else if (IsTaunting() || HasTargetReflection()) { // Taunting/Aggro adjustments
 			adjustment_needed =
-				is_too_close ||
+				(IsTaunting() && is_too_close) ||
 				los_adjust ||
 				(is_melee && !input.front_mob);
 


### PR DESCRIPTION
# Description

- Casters could endlessly flee a mob if they had TargetReflection and were too close.
- Prevents all bots that aren't taunting from adjusting if they're too close and have target reflection. This is safer than limiting it to just casters and ranged bots to prevent situations where melee bots might not be able to outrun the mob to get to their melee range and continually flee.
- WE'LL GET THIS RIGHT EVENTUALLY /sigh, missed it on last PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Need it be said? Casters and ranged won't flee when mob approaches them with TargetReflection

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
