### PR TITLE
[Bots] Fix creation limit, spawn limit, level requirement checks

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -878,6 +878,7 @@ RULE_INT(Bots, MinStatusToBypassSpawnLimit, 100, "Minimum status to bypass spawn
 RULE_INT(Bots, MinStatusBypassSpawnLimit, 120, "Spawn limit with status bypass. Default 120.")
 RULE_INT(Bots, MinStatusToBypassCreateLimit, 100, "Minimum status to bypass create limit. Default 100.")
 RULE_INT(Bots, MinStatusBypassCreateLimit, 120, "Create limit with status bypass. Default 120.")
+RULE_INT(Bots, MinStatusToBypassBotLevelRequirement, 100, "Minimum status to bypass level requirement for bots. Default 100.")
 RULE_BOOL(Bots, EnableBotTGB, true, "If enabled bots will cast group buffs as TGB.")
 RULE_BOOL(Bots, DoResponseAnimations, true, "If enabled bots will do animations to certain responses or commands.")
 RULE_INT(Bots, DefaultFollowDistance, 20, "Default 20. Distance a bot will follow behind.")

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -8715,6 +8715,155 @@ bool Bot::CheckCampSpawnConditions(Client* c) {
 	return true;
 }
 
+bool Bot::CheckHighEnoughLevelForBots(Client* c) {
+	auto bot_character_level = c->GetBotRequiredLevel();
+	bool not_high_enough_level = bot_character_level >= 0 && c->GetLevel() < bot_character_level;
+
+	if (not_high_enough_level) {
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"You must be level {} to spawn bots.",
+				bot_character_level
+			).c_str()
+		);
+
+		return false;
+	}
+
+	return true;
+}
+
+bool Bot::CheckHighEnoughLevelForBotsByClass(Client* c, uint8 bot_class) {
+	auto bot_character_level_class = c->GetBotRequiredLevel(bot_class);
+	bool not_high_enough_level_class = bot_character_level_class >= 0 && c->GetLevel() < bot_character_level_class;
+
+	if (not_high_enough_level_class) {
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"You must be level {} to spawn {} bots.",
+				bot_character_level_class,
+				GetClassIDName(bot_class)
+			).c_str()
+		);
+
+		return false;
+	}
+
+	return true;
+}
+
+bool Bot::CheckCreateLimit(Client* c, uint32 bot_count) {
+	auto bot_creation_limit = c->GetBotCreationLimit();
+	bool is_beyond_create_limit = bot_creation_limit >= 0 && bot_count >= bot_creation_limit;
+
+	if (is_beyond_create_limit) {
+		std::string message;
+
+		if (bot_creation_limit) {
+			message = fmt::format(
+				"You cannot create anymore than {} bot{}.",
+				bot_creation_limit,
+				bot_creation_limit != 1 ? "s" : ""
+			);
+		} else {
+			message = "You cannot create any bots.";
+		}
+
+		c->Message(Chat::Yellow, message.c_str());
+
+		return false;
+	}
+
+	return true;
+}
+
+bool Bot::CheckCreateLimitByClass(Client* c, uint8 bot_class, uint32 bot_class_count) {
+	auto bot_creation_limit_class = c->GetBotCreationLimit(bot_class);
+	bool is_beyond_class_spawn_limit = bot_creation_limit_class >= 0 && bot_class_count >= bot_creation_limit_class;
+
+	if (is_beyond_class_spawn_limit) {
+		std::string message;
+
+		if (bot_creation_limit_class) {
+			message = fmt::format(
+				"You cannot create anymore than {} {} bot{}.",
+				bot_creation_limit_class,
+				GetClassIDName(bot_class),
+				bot_creation_limit_class != 1 ? "s" : ""
+			);
+		} else {
+			message = fmt::format(
+				"You cannot create any {} bots.",
+				GetClassIDName(bot_class)
+			);
+		}
+
+		c->Message(Chat::Yellow, message.c_str());
+
+		return false;
+	}
+
+	return true;
+}
+bool Bot::CheckSpawnLimit(Client* c) {
+	auto bot_spawn_limit = c->GetBotSpawnLimit();
+	auto spawned_bots_count = Bot::SpawnedBotCount(c->CharacterID());
+	bool is_beyond_spawn_limit = bot_spawn_limit >= 0 && spawned_bots_count >= bot_spawn_limit;
+
+	if (is_beyond_spawn_limit) {
+		std::string message;
+
+		if (bot_spawn_limit) {
+			message = fmt::format(
+				"You cannot have more than {} spawned bot{}.",
+				bot_spawn_limit,
+				bot_spawn_limit != 1 ? "s" : ""
+			);
+		}
+		else {
+			message = "You are not currently allowed to spawn any bots.";
+		}
+
+		c->Message(Chat::White, message.c_str());
+		return false;
+	}
+
+	return true;
+}
+
+bool Bot::CheckSpawnLimitByClass(Client* c, uint8 bot_class) {
+	auto bot_spawn_limit_class = c->GetBotSpawnLimit(bot_class);
+	auto spawned_bot_count_class = Bot::SpawnedBotCount(c->CharacterID(), bot_class);
+	bool is_beyond_class_spawn_limit = bot_spawn_limit_class >= 0 && spawned_bot_count_class >= bot_spawn_limit_class;
+
+	if (is_beyond_class_spawn_limit) {
+		std::string message;
+
+		if (bot_spawn_limit_class) {
+			message = fmt::format(
+				"You cannot have more than {} spawned {} bot{}.",
+				bot_spawn_limit_class,
+				GetClassIDName(bot_class),
+				bot_spawn_limit_class != 1 ? "s" : ""
+			);
+		}
+		else {
+			message = fmt::format(
+				"You are not currently allowed to spawn any {} bots.",
+				GetClassIDName(bot_class)
+			);
+		}
+
+		c->Message(Chat::White, message.c_str());
+
+		return false;
+	}
+
+	return true;
+}
+
 void Bot::AddBotStartingItems(uint16 race_id, uint8 class_id)
 {
 	if (!IsPlayerRace(race_id) || !IsPlayerClass(class_id)) {

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -8715,16 +8715,17 @@ bool Bot::CheckCampSpawnConditions(Client* c) {
 	return true;
 }
 
-bool Bot::CheckHighEnoughLevelForBots(Client* c) {
-	auto bot_character_level = c->GetBotRequiredLevel();
+bool Bot::CheckHighEnoughLevelForBots(Client* c, uint8 bot_class) {
+	auto bot_character_level = c->GetBotRequiredLevel(bot_class);
 	bool not_high_enough_level = bot_character_level >= 0 && c->GetLevel() < bot_character_level;
 
 	if (not_high_enough_level) {
 		c->Message(
 			Chat::White,
 			fmt::format(
-				"You must be level {} to spawn bots.",
-				bot_character_level
+				"You must be level {} to spawn {}bots.",
+				bot_character_level,
+				bot_class ? GetClassIDName(bot_class) : ""
 			).c_str()
 		);
 
@@ -8734,69 +8735,24 @@ bool Bot::CheckHighEnoughLevelForBots(Client* c) {
 	return true;
 }
 
-bool Bot::CheckHighEnoughLevelForBotsByClass(Client* c, uint8 bot_class) {
-	auto bot_character_level_class = c->GetBotRequiredLevel(bot_class);
-	bool not_high_enough_level_class = bot_character_level_class >= 0 && c->GetLevel() < bot_character_level_class;
+bool Bot::CheckCreateLimit(Client* c, uint32 bot_count, uint8 bot_class) {
+	auto bot_creation_limit = c->GetBotCreationLimit(bot_class);
+	bool is_beyond_spawn_limit = bot_creation_limit >= 0 && bot_count >= bot_creation_limit;
 
-	if (not_high_enough_level_class) {
-		c->Message(
-			Chat::White,
-			fmt::format(
-				"You must be level {} to spawn {} bots.",
-				bot_character_level_class,
-				GetClassIDName(bot_class)
-			).c_str()
-		);
-
-		return false;
-	}
-
-	return true;
-}
-
-bool Bot::CheckCreateLimit(Client* c, uint32 bot_count) {
-	auto bot_creation_limit = c->GetBotCreationLimit();
-	bool is_beyond_create_limit = bot_creation_limit >= 0 && bot_count >= bot_creation_limit;
-
-	if (is_beyond_create_limit) {
+	if (is_beyond_spawn_limit) {
 		std::string message;
 
 		if (bot_creation_limit) {
 			message = fmt::format(
-				"You cannot create anymore than {} bot{}.",
+				"You cannot create anymore than {} {}bot{}.",
 				bot_creation_limit,
+				bot_class ? GetClassIDName(bot_class) : "",
 				bot_creation_limit != 1 ? "s" : ""
 			);
 		} else {
-			message = "You cannot create any bots.";
-		}
-
-		c->Message(Chat::Yellow, message.c_str());
-
-		return false;
-	}
-
-	return true;
-}
-
-bool Bot::CheckCreateLimitByClass(Client* c, uint8 bot_class, uint32 bot_class_count) {
-	auto bot_creation_limit_class = c->GetBotCreationLimit(bot_class);
-	bool is_beyond_class_spawn_limit = bot_creation_limit_class >= 0 && bot_class_count >= bot_creation_limit_class;
-
-	if (is_beyond_class_spawn_limit) {
-		std::string message;
-
-		if (bot_creation_limit_class) {
 			message = fmt::format(
-				"You cannot create anymore than {} {} bot{}.",
-				bot_creation_limit_class,
-				GetClassIDName(bot_class),
-				bot_creation_limit_class != 1 ? "s" : ""
-			);
-		} else {
-			message = fmt::format(
-				"You cannot create any {} bots.",
-				GetClassIDName(bot_class)
+				"You cannot create any {}bots.",
+				bot_class ? GetClassIDName(bot_class) : ""
 			);
 		}
 
@@ -8807,52 +8763,27 @@ bool Bot::CheckCreateLimitByClass(Client* c, uint8 bot_class, uint32 bot_class_c
 
 	return true;
 }
-bool Bot::CheckSpawnLimit(Client* c) {
-	auto bot_spawn_limit = c->GetBotSpawnLimit();
-	auto spawned_bots_count = Bot::SpawnedBotCount(c->CharacterID());
-	bool is_beyond_spawn_limit = bot_spawn_limit >= 0 && spawned_bots_count >= bot_spawn_limit;
+
+bool Bot::CheckSpawnLimit(Client* c, uint8 bot_class) {
+	auto bot_spawn_limit = c->GetBotSpawnLimit(bot_class);
+	auto spawned_bot_count = Bot::SpawnedBotCount(c->CharacterID(), bot_class);
+	bool is_beyond_spawn_limit = bot_spawn_limit >= 0 && spawned_bot_count >= bot_spawn_limit;
 
 	if (is_beyond_spawn_limit) {
 		std::string message;
 
 		if (bot_spawn_limit) {
 			message = fmt::format(
-				"You cannot have more than {} spawned bot{}.",
+				"You cannot have more than {} spawned {}bot{}.",
 				bot_spawn_limit,
+				bot_class ? GetClassIDName(bot_class) : "",
 				bot_spawn_limit != 1 ? "s" : ""
 			);
 		}
 		else {
-			message = "You are not currently allowed to spawn any bots.";
-		}
-
-		c->Message(Chat::White, message.c_str());
-		return false;
-	}
-
-	return true;
-}
-
-bool Bot::CheckSpawnLimitByClass(Client* c, uint8 bot_class) {
-	auto bot_spawn_limit_class = c->GetBotSpawnLimit(bot_class);
-	auto spawned_bot_count_class = Bot::SpawnedBotCount(c->CharacterID(), bot_class);
-	bool is_beyond_class_spawn_limit = bot_spawn_limit_class >= 0 && spawned_bot_count_class >= bot_spawn_limit_class;
-
-	if (is_beyond_class_spawn_limit) {
-		std::string message;
-
-		if (bot_spawn_limit_class) {
 			message = fmt::format(
-				"You cannot have more than {} spawned {} bot{}.",
-				bot_spawn_limit_class,
-				GetClassIDName(bot_class),
-				bot_spawn_limit_class != 1 ? "s" : ""
-			);
-		}
-		else {
-			message = fmt::format(
-				"You are not currently allowed to spawn any {} bots.",
-				GetClassIDName(bot_class)
+				"You are not currently allowed to spawn any {}bots.",
+				bot_class ? GetClassIDName(bot_class) : ""
 			);
 		}
 

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -1105,13 +1105,9 @@ public:
 
 	// Public "Refactor" Methods
 	static bool CheckCampSpawnConditions(Client* c);
-	static bool CheckHighEnoughLevelForBots(Client* c);
-	static bool CheckHighEnoughLevelForBotsByClass(Client* c, uint8 bot_class);
-	static bool CheckCreateLimit(Client* c, uint32 bot_count);
-	static bool CheckCreateLimitByClass(Client* c, uint8 bot_class, uint32 bot_class_count);
-	static bool CheckSpawnLimit(Client* c);
-	static bool CheckSpawnLimitByClass(Client* c, uint8 bot_class);
-
+	static bool CheckHighEnoughLevelForBots(Client* c, uint8 bot_class = Class::None);
+	static bool CheckCreateLimit(Client* c, uint32 bot_count, uint8 bot_class = Class::None);
+	static bool CheckSpawnLimit(Client* c, uint8 bot_class = Class::None);
 
 protected:
 	void BotMeditate(bool is_sitting);

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -1105,6 +1105,13 @@ public:
 
 	// Public "Refactor" Methods
 	static bool CheckCampSpawnConditions(Client* c);
+	static bool CheckHighEnoughLevelForBots(Client* c);
+	static bool CheckHighEnoughLevelForBotsByClass(Client* c, uint8 bot_class);
+	static bool CheckCreateLimit(Client* c, uint32 bot_count);
+	static bool CheckCreateLimitByClass(Client* c, uint8 bot_class, uint32 bot_class_count);
+	static bool CheckSpawnLimit(Client* c);
+	static bool CheckSpawnLimitByClass(Client* c, uint8 bot_class);
+
 
 protected:
 	void BotMeditate(bool is_sitting);

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -521,7 +521,7 @@ uint32 helper_bot_create(Client *bot_owner, std::string bot_name, uint8 bot_clas
 		return bot_id;
 	}
 
-	if (!Bot::CheckHighEnoughLevelForBotsByClass(bot_owner, bot_class)) {
+	if (!Bot::CheckHighEnoughLevelForBots(bot_owner, bot_class)) {
 		return bot_id;
 	}
 
@@ -538,7 +538,7 @@ uint32 helper_bot_create(Client *bot_owner, std::string bot_name, uint8 bot_clas
 		return bot_id;
 	}
 
-	if (!Bot::CheckCreateLimitByClass(bot_owner, bot_class, bot_class_count)) {
+	if (!Bot::CheckCreateLimit(bot_owner, bot_class_count, bot_class)) {
 		return bot_id;
 	}
 

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -517,87 +517,30 @@ uint32 helper_bot_create(Client *bot_owner, std::string bot_name, uint8 bot_clas
 		return bot_id;
 	}
 
-	auto bot_creation_limit = bot_owner->GetBotCreationLimit();
-	auto bot_creation_limit_class = bot_owner->GetBotCreationLimit(bot_class);
+	if (!Bot::CheckHighEnoughLevelForBots(bot_owner)) {
+		return bot_id;
+	}
+
+	if (!Bot::CheckHighEnoughLevelForBotsByClass(bot_owner, bot_class)) {
+		return bot_id;
+	}
 
 	uint32 bot_count = 0;
 	uint32 bot_class_count = 0;
+
 	if (!database.botdb.QueryBotCount(bot_owner->CharacterID(), bot_class, bot_count, bot_class_count)) {
 		bot_owner->Message(Chat::Yellow, "Failed to query bot count.");
+
 		return bot_id;
 	}
 
-	if (bot_creation_limit >= 0 && bot_count >= bot_creation_limit) {
-		std::string message;
-
-		if (bot_creation_limit) {
-			message = fmt::format(
-				"You cannot create anymore than {} bot{}.",
-				bot_creation_limit,
-				bot_creation_limit != 1 ? "s" : ""
-			);
-		} else {
-			message = "You cannot create any bots.";
-		}
-
-		bot_owner->Message(Chat::Yellow, message.c_str());
+	if (!Bot::CheckCreateLimit(bot_owner, bot_count)) {
 		return bot_id;
 	}
 
-	if (bot_creation_limit_class >= 0 && bot_class_count >= bot_creation_limit_class) {
-		std::string message;
-
-		if (bot_creation_limit_class) {
-			message = fmt::format(
-				"You cannot create anymore than {} {} bot{}.",
-				bot_creation_limit_class,
-				GetClassIDName(bot_class),
-				bot_creation_limit_class != 1 ? "s" : ""
-			);
-		} else {
-			message = fmt::format(
-				"You cannot create any {} bots.",
-				GetClassIDName(bot_class)
-			);
-		}
-
-		bot_owner->Message(Chat::Yellow, message.c_str());
+	if (!Bot::CheckCreateLimitByClass(bot_owner, bot_class, bot_class_count)) {
 		return bot_id;
 	}
-
-	auto bot_character_level = bot_owner->GetBotRequiredLevel();
-
-	if (
-		bot_character_level >= 0 &&
-		bot_owner->GetLevel() < bot_character_level
-	) {
-		bot_owner->Message(
-			Chat::Yellow,
-			fmt::format(
-				"You must be level {} to use bots.",
-				bot_character_level
-			).c_str()
-		);
-		return bot_id;
-	}
-
-	auto bot_character_level_class = bot_owner->GetBotRequiredLevel(bot_class);
-
-	if (
-		bot_character_level_class >= 0 &&
-		bot_owner->GetLevel() < bot_character_level_class
-	) {
-		bot_owner->Message(
-			Chat::Yellow,
-			fmt::format(
-				"You must be level {} to use {} bots.",
-				bot_character_level_class,
-				GetClassIDName(bot_class)
-			).c_str()
-		);
-		return bot_id;
-	}
-
 
 	auto my_bot = new Bot(Bot::CreateDefaultNPCTypeStructForBot(bot_name, "", bot_owner->GetLevel(), bot_race, bot_class, bot_gender), bot_owner);
 

--- a/zone/bot_commands/bot.cpp
+++ b/zone/bot_commands/bot.cpp
@@ -157,7 +157,7 @@ void bot_command_clone(Client *c, const Seperator *sep)
 		return;
 	}
 
-	if (!Bot::CheckCreateLimitByClass(c, my_bot->GetClass(), bot_class_count)) {
+	if (!Bot::CheckCreateLimit(c, bot_class_count, my_bot->GetClass())) {
 		return;
 	}
 
@@ -954,11 +954,11 @@ void bot_command_spawn(Client *c, const Seperator *sep)
 		return;
 	}
 
-	if (!Bot::CheckHighEnoughLevelForBotsByClass(c, bot_class)) {
+	if (!Bot::CheckHighEnoughLevelForBots(c, bot_class)) {
 		return;
 	}
 
-	if (!Bot::CheckSpawnLimitByClass(c, bot_class)) {
+	if (!Bot::CheckSpawnLimit(c, bot_class)) {
 		return;
 	}
 

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -207,7 +207,7 @@ bool BotDatabase::QueryBotCount(const uint32 owner_id, int class_id, uint32& bot
 	bot_count = BotDataRepository::Count(
 		database,
 		fmt::format(
-			"`owner_id` = {}",
+			"`owner_id` = {} AND `name` NOT LIKE '%-deleted-%'",
 			owner_id
 		)
 	);
@@ -216,7 +216,7 @@ bool BotDatabase::QueryBotCount(const uint32 owner_id, int class_id, uint32& bot
 		bot_class_count = BotDataRepository::Count(
 			database,
 			fmt::format(
-				"`owner_id` = {} AND `class` = {}",
+				"`owner_id` = {} AND `class` = {} AND `name` NOT LIKE '%-deleted-%'",
 				owner_id,
 				class_id
 			)


### PR DESCRIPTION
# Description

- Previously if buckets were being used to control any of these values and the appropriate rule was set to 0, unset class specific buckets would override the main limit buckets.
- For example, if `Bots:SpawnLimit` is set to `0` and a player has their `bot_spawn_limit` set to `5` but they don't have a class bucket set for the class they're attempting to spawn (a Cleric), the unset `bot_spawn_limit_Cleric` would return 0 and prevent Clerics from being spawned.
- This affected spawn limits, creation limits and level requirements to use bots if controlled by buckets.
- This also fixes QueryBotCount to not account for soft deleted bots (`-deleted-`)
- `#gm on` is required to be on for those beyond the ruled min status requirements to bypass the limits.

Fixes [Bot Spawn Limitation](https://discord.com/channels/212663220849213441/1363204428089393373).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Tested every scenario of set unset rules/buckets.
---------------
### Rules
![rules](https://github.com/user-attachments/assets/69b27948-face-4f10-88fc-43b4b9803142)
- `Bots:BotCharacterLevel` - All players must be level `5` to **create** _and_ **spawn** bots
- `Bots:CreationLimit` - All players can only **create** `3` bots
- `Bots:SpawnLimit` - All players can only **spawn** `3` bots
- `Bots:MinStatusToBypassBotLevelRequirement` - Those beyond status `100` can create/spawn bots at any level with `#gm on`
- `Bots:MinStatusToBypassCreateLimit` - Those beyond status `100` can **create** up to `Bots:MinStatusBypassCreateLimit` (`120`) bots with `#gm on`
- `Bots:MinStatusToBypassSpawnLimit` - Those beyond status `100` can **spawn** up to `Bots:MinStatusBypassSpawnLimit` (`120`) bots with `#gm on`
---------------
### Data Buckets
![data_buckets](https://github.com/user-attachments/assets/bd4d1f0b-83a6-4123-a5bc-112229cc2b78)
*The following apply to `character_id` = `1`*:
- `bot_required_level` - Can create and spawn bots at level `2`
- `bot_required_level_Cleric` - Cannot create or spawn Cleric bots until level `5`
- `bot_creation_limit` - Can create `10` bots
- `bot_creation_limit_Cleric` - Can only create `2` Cleric bots
- `bot_spawn_limit` - Can spawn up to `5` bots
- `bot_spawn_limit_Cleric` - Can only create `1` Cleric bot

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
