### PR TITLE
[Bots] Move all spell_id instances to uint16

### DIFF
--- a/zone/bot.h
+++ b/zone/bot.h
@@ -747,7 +747,7 @@ public:
 	static BotSpell GetBestBotSpellForGroupCompleteHeal(Bot* caster, Mob* tar, uint16 spell_type = BotSpellTypes::RegularHeal);
 	static BotSpell GetBestBotSpellForGroupHeal(Bot* caster, Mob* tar, uint16 spell_type = BotSpellTypes::RegularHeal);
 
-	static Mob* GetFirstIncomingMobToMez(Bot* caster, int16 spell_id, uint16 spell_type, bool AE);
+	static Mob* GetFirstIncomingMobToMez(Bot* caster, uint16 spell_id, uint16 spell_type, bool AE);
 	static BotSpell GetBestBotSpellForMez(Bot* caster, uint16 spell_type = BotSpellTypes::Mez);
 	static BotSpell GetBestBotMagicianPetSpell(Bot* caster, uint16 spell_type = BotSpellTypes::Pet);
 	static std::string GetBotMagicianPetType(Bot* caster);

--- a/zone/bot_structs.h
+++ b/zone/bot_structs.h
@@ -68,7 +68,7 @@ struct BotSpellSetting {
 
 struct BotSpells {
 	uint32		type;			// 0 = never, must be one (and only one) of the defined values
-	int16		spellid;			// <= 0 = no spell
+	uint16		spellid;			// <= 0 = no spell
 	int16		manacost;		// -1 = use spdat, -2 = no cast time
 	uint32		time_cancast;	// when we can cast this spell next
 	int32		recast_delay;
@@ -86,7 +86,7 @@ struct BotSpells {
 struct BotSpells_wIndex {
 	uint32		index;			//index of AIBot_spells
 	uint32		type;			// 0 = never, must be one (and only one) of the defined values
-	int16		spellid;			// <= 0 = no spell
+	uint16		spellid;			// <= 0 = no spell
 	int16		manacost;		// -1 = use spdat, -2 = no cast time
 	uint32		time_cancast;	// when we can cast this spell next
 	int32		recast_delay;

--- a/zone/bot_structs.h
+++ b/zone/bot_structs.h
@@ -68,7 +68,7 @@ struct BotSpellSetting {
 
 struct BotSpells {
 	uint32		type;			// 0 = never, must be one (and only one) of the defined values
-	uint16		spellid;			// <= 0 = no spell
+	uint16		spellid;		// <= 0 = no spell
 	int16		manacost;		// -1 = use spdat, -2 = no cast time
 	uint32		time_cancast;	// when we can cast this spell next
 	int32		recast_delay;
@@ -86,7 +86,7 @@ struct BotSpells {
 struct BotSpells_wIndex {
 	uint32		index;			//index of AIBot_spells
 	uint32		type;			// 0 = never, must be one (and only one) of the defined values
-	uint16		spellid;			// <= 0 = no spell
+	uint16		spellid;		// <= 0 = no spell
 	int16		manacost;		// -1 = use spdat, -2 = no cast time
 	uint32		time_cancast;	// when we can cast this spell next
 	int32		recast_delay;

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -1459,7 +1459,7 @@ BotSpell Bot::GetBestBotSpellForMez(Bot* caster, uint16 spell_type) {
 	return result;
 }
 
-Mob* Bot::GetFirstIncomingMobToMez(Bot* caster, int16 spell_id, uint16 spell_type, bool AE) {
+Mob* Bot::GetFirstIncomingMobToMez(Bot* caster, uint16 spell_id, uint16 spell_type, bool AE) {
 	Mob* result = nullptr;
 
 	if (caster && caster->GetOwner()) {


### PR DESCRIPTION
# Description

- Converts instances of `spellid` / `spell_id` to uint16 to avoid overflow beyond 32,767 up to the RoF2 client's maximum limit (45k)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Fixes

- [Bots and Spell IDs](https://discord.com/channels/212663220849213441/1367575286111273164)
- [Overflow](https://discord.com/channels/212663220849213441/1358158655354048704/1358819991704830166)


# Testing

### Before:
```
You say, '^spells'
Spell 1 | Spell: Silent Piety (ID: 8029) | Add Spell: Add
Spell 2 | Spell: Armor of the Champion (ID: 5291) | Add Spell: Add
Spell 3 | Spell: Valor of Marr (ID: 2585) | Add Spell: Add
Spell 4 | Spell: Pious Fury (ID: 5288) | Add Spell: Add
Spell 5 | Spell: Brell's Brawny Bulwark (ID: 5297) | Add Spell: Add
Spell 6 | Spell: ÿÿÿÿ (ID: -25458) | Add Spell: Add
Spell 7 | Spell: Holyforge Discipline (ID: 4500) | Add Spell: Add
Spell 8 | Spell: Deflection Discipline (ID: 4590) | Add Spell: Add
Spell 9 | Spell: Fearless Discipline (ID: 4587) | Add Spell: Add
Spell 10 | Spell: Sanctification Discipline (ID: 4518) | Add Spell: Add
Spell 11 | Spell: Guard of Righteousness (ID: 6663) | Add Spell: Add
Spell 12 | Spell: Ancient: Force of Jeron (ID: 5299) | Add Spell: Add
Spell 13 | Spell: Divine Favor (ID: 1743) | Add Spell: Add
Spell 14 | Spell: Healing Wave of Prexus (ID: 2589) | Add Spell: Add
Spell 15 | Spell: Light of Piety (ID: 5289) | Add Spell: Add
Spell 16 | Spell: Last Rites (ID: 8027) | Add Spell: Add
Spell 17 | Spell: Affirmation (ID: 5298) | Add Spell: Add
Spell 18 | Spell: Remove Greater Curse (ID: 2880) | Add Spell: Add
Spell 19 | Spell: Crusader's Purity (ID: 5283) | Add Spell: Add
Spell 20 | Spell: Trial for Honor Rk. II (ID: 14955) | Add Spell: Add
Spell 21 | Spell: Trial for Honor Rk. III (ID: 14956) | Add Spell: Add
Spell 22 | Spell: Trial for Honor Rk. II (ID: 14955) | Add Spell: Add
Spell 23 | Spell: ^spellinfo -25457 (ID: -25457) | Add Spell: Add
Spell 24 | Spell: Divine Aura (ID: 207) | Add Spell: Add
Spell 25 | Spell: oonfire Rk. III (ID: -25456) | Add Spell: Add
Spell 26 | Spell: Resistant Discipline (ID: 4585) | Add Spell: Add
Spell 27 | Spell: Fearless Discipline (ID: 4587) | Add Spell: Add
Spell 28 | Spell: Holyforge Discipline (ID: 4500) | Add Spell: Add
Spell 29 | Spell: Deflection Discipline (ID: 4590) | Add Spell: Add
Spell 30 | Spell: Sanctification Discipline (ID: 4518) | Add Spell: Add
Spell 31 | Spell: Guard of Righteousness (ID: 6663) | Add Spell: Add
Spell 32 | Spell: Trial for Honor Rk. III (ID: 14956) | Add Spell: Add
Spell 33 | Spell: Invisibility versus Undead (ID: 235) | Add Spell: Add
Spell 34 | Spell: Divine Favor (ID: 1743) | Add Spell: Add
Spell 35 | Spell: Pacify (ID: 45) | Add Spell: Add
Protector has 35 AI Spells.
```
----
```
Spell 6 | Spell: ÿÿÿÿ (ID: -25458) | Add Spell: Add
Spell 23 | Spell: ^spellinfo -25457 (ID: -25457) | Add Spell: Add
Spell 25 | Spell: oonfire Rk. III (ID: -25456) | Add Spell: Add
```

### After:
```
You say, '^spells'
Spell 1 | Spell: Silent Piety (ID: 8029) | Add Spell: Add
Spell 2 | Spell: Armor of the Champion (ID: 5291) | Add Spell: Add
Spell 3 | Spell: Valor of Marr (ID: 2585) | Add Spell: Add
Spell 4 | Spell: Pious Fury (ID: 5288) | Add Spell: Add
Spell 5 | Spell: Brell's Brawny Bulwark (ID: 5297) | Add Spell: Add
Spell 6 | Spell: Valiant Deflection (ID: 40078) | Add Spell: Add
Spell 7 | Spell: Holyforge Discipline (ID: 4500) | Add Spell: Add
Spell 8 | Spell: Deflection Discipline (ID: 4590) | Add Spell: Add
Spell 9 | Spell: Fearless Discipline (ID: 4587) | Add Spell: Add
Spell 10 | Spell: Sanctification Discipline (ID: 4518) | Add Spell: Add
Spell 11 | Spell: Guard of Righteousness (ID: 6663) | Add Spell: Add
Spell 12 | Spell: Ancient: Force of Jeron (ID: 5299) | Add Spell: Add
Spell 13 | Spell: Divine Favor (ID: 1743) | Add Spell: Add
Spell 14 | Spell: Healing Wave of Prexus (ID: 2589) | Add Spell: Add
Spell 15 | Spell: Light of Piety (ID: 5289) | Add Spell: Add
Spell 16 | Spell: Last Rites (ID: 8027) | Add Spell: Add
Spell 17 | Spell: Affirmation (ID: 5298) | Add Spell: Add
Spell 18 | Spell: Remove Greater Curse (ID: 2880) | Add Spell: Add
Spell 19 | Spell: Crusader's Purity (ID: 5283) | Add Spell: Add
Spell 20 | Spell: Trial for Honor Rk. II (ID: 14955) | Add Spell: Add
Spell 21 | Spell: Trial for Honor Rk. III (ID: 14956) | Add Spell: Add
Spell 22 | Spell: Trial for Honor Rk. II (ID: 14955) | Add Spell: Add
Spell 23 | Spell: Valiant Deflection Rk. II (ID: 40079) | Add Spell: Add
Spell 24 | Spell: Divine Aura (ID: 207) | Add Spell: Add
Spell 25 | Spell: Valiant Deflection Rk. III (ID: 40080) | Add Spell: Add
Spell 26 | Spell: Resistant Discipline (ID: 4585) | Add Spell: Add
Spell 27 | Spell: Fearless Discipline (ID: 4587) | Add Spell: Add
Spell 28 | Spell: Holyforge Discipline (ID: 4500) | Add Spell: Add
Spell 29 | Spell: Deflection Discipline (ID: 4590) | Add Spell: Add
Spell 30 | Spell: Sanctification Discipline (ID: 4518) | Add Spell: Add
Spell 31 | Spell: Guard of Righteousness (ID: 6663) | Add Spell: Add
Spell 32 | Spell: Trial for Honor Rk. III (ID: 14956) | Add Spell: Add
Spell 33 | Spell: Invisibility versus Undead (ID: 235) | Add Spell: Add
Spell 34 | Spell: Divine Favor (ID: 1743) | Add Spell: Add
Spell 35 | Spell: Pacify (ID: 45) | Add Spell: Add
Protector has 35 AI Spells.
```
----
```
Spell 6 | Spell: Valiant Deflection (ID: 40078) | Add Spell: Add
Spell 23 | Spell: Valiant Deflection Rk. II (ID: 40079) | Add Spell: Add
Spell 25 | Spell: Valiant Deflection Rk. III (ID: 40080) | Add Spell: Add
```

- This could also result in an occasional crash in `Bot::ListBotSpells` via the `^spells` commands.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
