### PR TITLE
[Doors] Fix door saving for versions

### DIFF
--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -852,11 +852,13 @@ void Doors::CreateDatabaseEntry()
 	const auto& l = DoorsRepository::GetWhere(
 		content_db,
 		fmt::format(
-			"zone = '{}' AND doorid = {}",
+			"zone = '{}' AND version = {} AND doorid = {}",
 			zone->GetShortName(),
+			zone->GetInstanceVersion(),
 			GetDoorID()
 		)
 	);
+
 	if (!l.empty()) {
 		auto e = l[0];
 

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -852,7 +852,7 @@ void Doors::CreateDatabaseEntry()
 	const auto& l = DoorsRepository::GetWhere(
 		content_db,
 		fmt::format(
-			"zone = '{}' AND version = {} AND doorid = {}",
+			"zone = '{}' AND (version = {} OR version = -1) AND doorid = {}",
 			zone->GetShortName(),
 			zone->GetInstanceVersion(),
 			GetDoorID()


### PR DESCRIPTION
# Description

- Door saving wasn't saving to the proper version on `#door save`

Fixes [[video] bug in the door system when saving a door](https://discord.com/channels/212663220849213441/1375585145414877274)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Verified saving/loading/reloading in version 0 and version 1 of zones to ensure no overlap and proper saving to version.

Clients tested: 

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
