### PR TITLE
[Bots] Fix ^cast resurrects

### DIFF
--- a/common/spdat_bot.cpp
+++ b/common/spdat_bot.cpp
@@ -358,6 +358,7 @@ bool RequiresStackCheck(uint16 spell_type) {
 		case BotSpellTypes::CompleteHeal:
 		case BotSpellTypes::PetCompleteHeals:
 		case BotSpellTypes::GroupCompleteHeals:
+		case BotSpellTypes::Resurrect:
 			return false;
 		default:
 			return true;


### PR DESCRIPTION
# Description

- Was failing stack checks and couldn't be casted. Added bypass.

[Cleric Bot resurrection / ^cast resurrects doesn't work correctly](https://discord.com/channels/212663220849213441/1383872828440580305)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Verified able to rez corpse after bypass.

Clients tested:  RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
