### PR TITLE
[Bots] Fix FinishBuffing rule

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -9610,14 +9610,9 @@ bool Bot::CastChecks(uint16 spell_id, Mob* tar, uint16 spell_type, bool precheck
 		return false;
 	}
 
-	if (
-		!BotHasEnoughMana(spell_id) &&
-		(
-			!RuleB(Bots, FinishBuffing) ||
-			IsEngaged() ||
-			IsBotBuffSpellType(spell_type)
-		)
-	) {
+	bool is_mana_exempt = RuleB(Bots, FinishBuffing) && !IsEngaged() && IsBotBuffSpellType(spell_type);
+
+	if (!BotHasEnoughMana(spell_id) && !is_mana_exempt) {
 		LogBotSpellChecksDetail("{} says, 'Cancelling cast of {} due to !BotHasEnoughMana.'", GetCleanName(), GetSpellName(spell_id));
 		return false;
 	}


### PR DESCRIPTION
# Description

- Corrects logic for `Bots:FinishBuffing` during precast checks.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Verified before and after that the rule properly allows bots to buff if they do not have enough mana whereas they didn't previously.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
