### PR TITLE
[Bots] Allow melee to sit to med/heal when out of combat

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -2601,6 +2601,8 @@ void Bot::DoOutOfCombatChecks(Client* bot_owner, Mob* follow_mob, float leash_di
 	if (GetClass() == Class::Bard && AI_HasSpells() && TryBardMovementCasts()) {
 		return;
 	}
+
+	TryMeditate();
 }
 
 // This is as close as I could get without modifying the aggro mechanics and making it an expensive process...


### PR DESCRIPTION
# Description

Allows melee bots to sit and med when out of combat.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Verified melee bots will sit when combat has ended to heal if they are missing health.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
