### PR TITLE
fix: correct off-by-one in GetSpellLevel for Berserker class

### DIFF
--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -999,7 +999,7 @@ uint8 GetSpellLevel(uint16 spell_id, uint8 class_id)
 		return UINT8_MAX;
 	}
 
-	if (class_id >= Class::PLAYER_CLASS_COUNT) {
+	if (class_id < Class::Warrior || class_id > Class::Berserker) {
 		return UINT8_MAX;
 	}
 

--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -999,7 +999,7 @@ uint8 GetSpellLevel(uint16 spell_id, uint8 class_id)
 		return UINT8_MAX;
 	}
 
-	if (class_id < Class::Warrior || class_id > Class::Berserker) {
+	if (class_id < Class::Warrior || class_id > Class::PLAYER_CLASS_COUNT) {
 		return UINT8_MAX;
 	}
 


### PR DESCRIPTION
Fixes #5056

## What

`GetSpellLevel` in `common/spdat.cpp` returns `UINT8_MAX` (255) for any Berserker (class ID 16) due to an off-by-one in the boundary check.

```cpp
// Before
if (class_id >= Class::PLAYER_CLASS_COUNT) {  // 16 >= 16 → true → early return
    return UINT8_MAX;
}

// After
if (class_id < Class::Warrior || class_id > Class::Berserker) {
    return UINT8_MAX;
}
```

## Why

`Class::Berserker == 16` and `Class::PLAYER_CLASS_COUNT == 16`, so `>=` incorrectly rejects the highest valid class. The array access below (`classes[class_id - 1]` → `classes[15]`) is valid — the bug is only in the guard.

The new check uses named constants to make the valid range explicit and also covers `class_id == 0`, which would underflow the index.

The companion function `GetSpellMinimumLevel` uses `i < Class::PLAYER_CLASS_COUNT` (0-indexed loop through all 16 slots) and correctly includes Berserker, confirming the array is intended to cover all 16 classes.

The quest API wrappers (`embparser_api.cpp`, `lua_general.cpp`) pass the result through a MaxLevel check — since 255 > MaxLevel, the bug compounds and the scripting layer receives UINT8_MAX a second time, which is why the reported symptom is often 0 rather than 255.

## Note

New contributor here — happy to adjust anything that doesn't fit the project's conventions.