### PR TITLE
fix: include base skill damage in FlyingKick, Kick, RoundKick, and Bash

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -5175,7 +5175,7 @@ int Bot::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 				ac_bonus = inst->GetItemArmorClass(true) / 25.0f;
 			if (ac_bonus > skill_bonus)
 				ac_bonus = skill_bonus;
-			return static_cast<int>(ac_bonus + skill_bonus);
+			return base + static_cast<int>(ac_bonus + skill_bonus);
 		}
 		case EQ::skills::SkillKick: {
 			float skill_bonus = skill_level / 10.0f;
@@ -5185,7 +5185,7 @@ int Bot::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 				ac_bonus = inst->GetItemArmorClass(true) / 25.0f;
 			if (ac_bonus > skill_bonus)
 				ac_bonus = skill_bonus;
-			return static_cast<int>(ac_bonus + skill_bonus);
+			return base + static_cast<int>(ac_bonus + skill_bonus);
 		}
 		case EQ::skills::SkillBash: {
 			float skill_bonus = skill_level / 10.0f;
@@ -5199,7 +5199,7 @@ int Bot::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 				ac_bonus = inst->GetItemArmorClass(true) / 25.0f;
 			if (ac_bonus > skill_bonus)
 				ac_bonus = skill_bonus;
-			return static_cast<int>(ac_bonus + skill_bonus);
+			return base + static_cast<int>(ac_bonus + skill_bonus);
 		}
 		case EQ::skills::SkillBackstab: {
 			float skill_bonus = static_cast<float>(skill_level) * 0.02f;

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -102,10 +102,10 @@ int Mob::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 			}
 
 			if (RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(skill) > 0) {
-				return static_cast<int>(ac_bonus + skill_bonus) * std::abs(GetSkillDmgAmt(skill) / 100);
+				return (base + static_cast<int>(ac_bonus + skill_bonus)) * std::abs(GetSkillDmgAmt(skill) / 100);
 			}
 
-			return static_cast<int>(ac_bonus + skill_bonus);
+			return base + static_cast<int>(ac_bonus + skill_bonus);
 		}
 		case EQ::skills::SkillKick:
 		case EQ::skills::SkillRoundKick: {
@@ -128,10 +128,10 @@ int Mob::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 			}
 
 			if (RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(skill) > 0) {
-				return static_cast<int>(ac_bonus + skill_bonus) * std::abs(GetSkillDmgAmt(skill) / 100);
+				return (base + static_cast<int>(ac_bonus + skill_bonus)) * std::abs(GetSkillDmgAmt(skill) / 100);
 			}
 
-			return static_cast<int>(ac_bonus + skill_bonus);
+			return base + static_cast<int>(ac_bonus + skill_bonus);
 		}
 		case EQ::skills::SkillBash: {
 			float                  skill_bonus = skill_level / 10.0f;
@@ -160,10 +160,10 @@ int Mob::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 			}
 
 			if (RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(skill) > 0) {
-				return static_cast<int>(ac_bonus + skill_bonus) * std::abs(GetSkillDmgAmt(skill) / 100);
+				return (base + static_cast<int>(ac_bonus + skill_bonus)) * std::abs(GetSkillDmgAmt(skill) / 100);
 			}
 
-			return static_cast<int>(ac_bonus + skill_bonus);
+			return base + static_cast<int>(ac_bonus + skill_bonus);
 		}
 		case EQ::skills::SkillBackstab: {
 			float skill_bonus = static_cast<float>(skill_level) * 0.02f;


### PR DESCRIPTION
Fixes #5035

## What

`GetBaseSkillDamage()` fetches each skill's configured base damage into `base` at line 35 via `EQ::skills::GetBaseDamage()` (which reads the `Combat:*BaseDamage` rules), but four skills discard it entirely and return only `(ac_bonus + skill_bonus)`. The same bug exists in both `Mob::GetBaseSkillDamage` (`zone/special_attacks.cpp`) and `Bot::GetBaseSkillDamage` (`zone/bot.cpp`).

| Skill | Fix |
|-------|-----|
| `SkillFlyingKick` | `return base + static_cast<int>(ac_bonus + skill_bonus)` |
| `SkillKick` | same |
| `SkillRoundKick` | same (Mob only — Bot has no RoundKick case) |
| `SkillBash` | same |

The working cases — `DragonPunch`, `EagleStrike`, `TigerClaw`, `Frenzy` — all correctly return `base` in both implementations.

## Why this is clearly a bug for Kick and RoundKick

The `Kick`/`RoundKick` case in `special_attacks.cpp` increments `base` at skill level 75 and again at 175, then throws it away. There is no reason to modify a value you're not going to use — those increments only make sense if `base` was intended to be part of the return.

## Gameplay impact — please review

This fix makes the `Combat:*BaseDamage` rules functional for the first time. With default rule values the damage changes per skill are:

| Skill | Default base | Approx damage change at max skill |
|-------|-------------|----------------------------------|
| `Kick` | 3 (+2 from skill thresholds = 5) | +5 |
| `RoundKick` | 5 (+2 from skill thresholds = 7) | +7 |
| `Bash` | 2 | +2 |
| `FlyingKick` | 25 | +25 |

`FlyingKick` has the largest impact due to its default rule value of 25. If that default was set before the bug existed and never reflected actual intended damage, it may need to be re-evaluated alongside this fix. We've documented the impact here and leave that call to the maintainers.

## Note

New contributor here — happy to adjust anything that doesn't fit the project's conventions.