### PR TITLE
fix: only dismiss pet summoned by the fading familiar buff

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -4394,9 +4394,9 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 			case SpellEffect::Familiar:
 			{
 				Mob *mypet = GetPet();
-				if (mypet){
-					if(mypet->IsNPC())
-						mypet->CastToNPC()->Depop();
+				if (mypet && mypet->IsNPC() &&
+				    mypet->CastToNPC()->GetPetSpellID() == buffs[slot].spellid) {
+					mypet->CastToNPC()->Depop();
 					SetPetID(0);
 				}
 				break;


### PR DESCRIPTION
Fixes #5026

## What

When a `SpellEffect::Familiar` buff fades in `Mob::BuffFadeBySlot`, the code called `GetPet()` and unconditionally depopulated whatever pet the player currently had — regardless of whether that pet was the familiar or a combat pet summoned later.

```cpp
// Before — kills whatever pet is currently active
Mob *mypet = GetPet();
if (mypet){
    if(mypet->IsNPC())
        mypet->CastToNPC()->Depop();
    SetPetID(0);
}

// After — only dismisses the pet summoned by this specific buff
Mob *mypet = GetPet();
if (mypet && mypet->IsNPC() &&
    mypet->CastToNPC()->GetPetSpellID() == buffs[slot].spellid) {
    mypet->CastToNPC()->Depop();
    SetPetID(0);
}
```

## Why this is correct

`NPC::pet_spell_id` is set during `Pet` construction via `SetPetSpellID(spell_id)` (pets.cpp:355) — every pet reliably carries the spell that summoned it. `buffs[slot].spellid` is the standard way to identify the fading buff throughout `BuffFadeBySlot`. Checking these match ensures we only dismiss the familiar that belongs to this buff.

## Scenarios covered

| Situation | Before | After |
|-----------|--------|-------|
| Familiar buff fades, familiar still active | Familiar dismissed ✓ | Familiar dismissed ✓ |
| Familiar buff fades, combat pet replaced familiar | Combat pet killed ✗ | Combat pet untouched ✓ |
| Familiar spell refreshed (buff overwrite path also calls `BuffFadeBySlot`) | Familiar dismissed, new one summoned ✓ | Same — spell IDs match, familiar dismissed, new one summoned ✓ |
| Familiar already gone, `GetPet()` returns null | No-op ✓ | No-op ✓ |

`GetPet()` already calls `SetPetID(0)` internally if the entity no longer exists (pets.cpp:417), so there is no leak if the familiar was previously despawned by other means.

## Verified

- `Bot::BuffFadeBySlot` does not exist as a separate override — Bots use `Mob::BuffFadeBySlot` and are covered by this fix

## Note

New contributor here — happy to adjust anything that doesn't fit the project's conventions.