### PR TITLE
CI tob_patch branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - tob_patch
   pull_request:
 
 jobs:


### PR DESCRIPTION
Add CI to the tob_patch branch so I don't get blamed when the branch isn't building~