### PR TITLE
Fix gcc warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ option(EQEMU_BUILD_PCH "Build with precompiled headers (Windows)" ON)
 
 if(MSVC)
 	add_compile_options(/bigobj)
-	add_compile_definitions(_CRT_SECURE_NO_WARNINGS NOMINMAX WIN32_LEAN_AND_MEAN CRASH_LOGGING _HAS_AUTO_PTR_ETC)
+	add_compile_definitions(_CRT_SECURE_NO_WARNINGS NOMINMAX WIN32_LEAN_AND_MEAN CRASH_LOGGING)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 
 	option(EQEMU_DISABLE_MSVC_WARNINGS "Disable MSVC compile warnings." OFF)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -6,6 +6,7 @@ set(common_sources
     bodytypes.cpp
     classes.cpp
     cli/eqemu_command_handler.cpp
+    compiler_macros.h
     compression.cpp
     content/world_content_service.cpp
     crash.cpp

--- a/common/compiler_macros.h
+++ b/common/compiler_macros.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#if defined(_MSC_VER)
+    #define PUSH_DISABLE_DEPRECATED_WARNINGS() __pragma(warning(push)) \
+                                               __pragma(warning(disable:4996))
+    #define POP_DISABLE_DEPRECATED_WARNINGS()  __pragma(warning(pop))
+#elif defined(__GNUC__) || defined(__clang__)
+    #define PUSH_DISABLE_DEPRECATED_WARNINGS() _Pragma("GCC diagnostic push") \
+                                               _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+    #define POP_DISABLE_DEPRECATED_WARNINGS()  _Pragma("GCC diagnostic pop")
+#else
+    #define PUSH_DISABLE_DEPRECATED_WARNINGS()
+    #define POP_DISABLE_DEPRECATED_WARNINGS()
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__)
+    #define UNREACHABLE() __assume(0)
+#else
+    #define UNREACHABLE() __builtin_unreachable()
+#endif

--- a/common/json/jsoncpp.cpp
+++ b/common/json/jsoncpp.cpp
@@ -271,11 +271,7 @@ static size_t const stackLimit_g = JSONCPP_DEPRECATED_STACK_LIMIT; // see readVa
 
 namespace Json {
 
-#if __cplusplus >= 201103L || (defined(_CPPLIB_VER) && _CPPLIB_VER >= 520)
 typedef std::unique_ptr<CharReader> CharReaderPtr;
-#else
-typedef std::auto_ptr<CharReader>   CharReaderPtr;
-#endif
 
 // Implementation of class Features
 // ////////////////////////////////
@@ -4153,11 +4149,7 @@ Value& Path::make(Value& root) const {
 
 namespace Json {
 
-#if __cplusplus >= 201103L || (defined(_CPPLIB_VER) && _CPPLIB_VER >= 520)
 typedef std::unique_ptr<StreamWriter> StreamWriterPtr;
-#else
-typedef std::auto_ptr<StreamWriter>   StreamWriterPtr;
-#endif
 
 static bool containsControlCharacter(const char* str) {
   while (*str) {

--- a/libs/luabind/luabind/adopt_policy.hpp
+++ b/libs/luabind/luabind/adopt_policy.hpp
@@ -103,7 +103,7 @@ namespace luabind { namespace detail
 			if (luabind::move_back_reference(L, ptr))
 				return;
 
-            make_instance(L, std::auto_ptr<T>(ptr));
+            make_instance(L, std::unique_ptr<T>(ptr));
 		}
 	};
 

--- a/libs/luabind/luabind/class.hpp
+++ b/libs/luabind/luabind/class.hpp
@@ -335,7 +335,7 @@ namespace luabind
         template <class T>
         struct default_pointer<null_type, T>
         {
-            typedef std::auto_ptr<T> type;
+            typedef std::unique_ptr<T> type;
         };
 
         template <class Class, class Pointer, class Signature, class Policies>

--- a/libs/luabind/luabind/detail/constructor.hpp
+++ b/libs/luabind/luabind/detail/constructor.hpp
@@ -46,7 +46,7 @@ struct construct_aux<0, T, Pointer, Signature>
         object_rep* self = touserdata<object_rep>(self_);
         class_rep* cls = self->crep();
 
-        std::auto_ptr<T> instance(new T);
+        std::unique_ptr<T> instance(new T);
         inject_backref(self_.interpreter(), instance.get(), instance.get());
 
         void* naked_ptr = instance.get();
@@ -55,7 +55,7 @@ struct construct_aux<0, T, Pointer, Signature>
         void* storage = self->allocate(sizeof(holder_type));
 
         self->set_instance(new (storage) holder_type(
-            ptr, registered_class<T>::id, naked_ptr, cls));
+            std::move(ptr), registered_class<T>::id, naked_ptr, cls));
     }
 };
 
@@ -92,7 +92,7 @@ struct construct_aux<N, T, Pointer, Signature>
         object_rep* self = touserdata<object_rep>(self_);
         class_rep* cls = self->crep();
 
-        std::auto_ptr<T> instance(new T(BOOST_PP_ENUM_PARAMS(N,_)));
+        std::unique_ptr<T> instance(new T(BOOST_PP_ENUM_PARAMS(N,_)));
         inject_backref(self_.interpreter(), instance.get(), instance.get());
 
         void* naked_ptr = instance.get();
@@ -101,7 +101,7 @@ struct construct_aux<N, T, Pointer, Signature>
         void* storage = self->allocate(sizeof(holder_type));
 
         self->set_instance(new (storage) holder_type(
-            ptr, registered_class<T>::id, naked_ptr, cls));
+            std::move(ptr), registered_class<T>::id, naked_ptr, cls));
     }
 };
 

--- a/libs/luabind/luabind/detail/has_get_pointer.hpp
+++ b/libs/luabind/luabind/detail/has_get_pointer.hpp
@@ -58,7 +58,7 @@ namespace has_get_pointer_
   T* get_pointer(T const volatile*);
 
   template<class T>
-  T* get_pointer(std::auto_ptr<T> const&);
+  T* get_pointer(std::unique_ptr<T> const&);
 
 # endif
 

--- a/libs/luabind/luabind/detail/instance_holder.hpp
+++ b/libs/luabind/luabind/detail/instance_holder.hpp
@@ -57,7 +57,7 @@ inline mpl::true_ check_const_pointer(void const*)
 }
 
 template <class T>
-void release_ownership(std::auto_ptr<T>& p)
+void release_ownership(std::unique_ptr<T>& p)
 {
     p.release();
 }
@@ -83,7 +83,7 @@ public:
         P p, class_id dynamic_id, void* dynamic_ptr, class_rep* cls
     )
       : instance_holder(cls, check_const_pointer(false ? get_pointer(p) : 0))
-      , p(p)
+      , p(std::move(p))
       , weak(0)
       , dynamic_id(dynamic_id)
       , dynamic_ptr(dynamic_ptr)

--- a/libs/luabind/luabind/detail/make_instance.hpp
+++ b/libs/luabind/luabind/detail/make_instance.hpp
@@ -88,7 +88,7 @@ void make_instance(lua_State* L, P p)
 
     try
     {
-        new (storage) holder_type(p, dynamic.first, dynamic.second, cls);
+        new (storage) holder_type(std::move(p), dynamic.first, dynamic.second, cls);
     }
     catch (...)
     {

--- a/libs/luabind/luabind/detail/policy.hpp
+++ b/libs/luabind/luabind/detail/policy.hpp
@@ -169,7 +169,7 @@ namespace luabind { namespace detail
     {
         if (get_pointer(x))
         {
-            make_instance(L, x);
+            make_instance(L, std::move(x));
         }
         else
         {
@@ -180,8 +180,8 @@ namespace luabind { namespace detail
     template <class T>
     void make_pointee_instance(lua_State* L, T& x, mpl::false_, mpl::true_)
     {
-        std::auto_ptr<T> ptr(new T(x));
-        make_instance(L, ptr);
+        std::unique_ptr<T> ptr(new T(x));
+        make_instance(L, std::move(ptr));
     }
 
     template <class T>

--- a/libs/luabind/luabind/function.hpp
+++ b/libs/luabind/luabind/function.hpp
@@ -46,7 +46,7 @@ namespace detail
 template <class F, class Policies>
 scope def(char const* name, F f, Policies const& policies)
 {
-    return scope(std::auto_ptr<detail::registration>(
+    return scope(std::unique_ptr<detail::registration>(
         new detail::function_registration<F, Policies>(name, f, policies)));
 }
 

--- a/libs/luabind/luabind/scope.hpp
+++ b/libs/luabind/luabind/scope.hpp
@@ -56,7 +56,7 @@ namespace luabind {
     struct LUABIND_API scope
     {
         scope();
-        explicit scope(std::auto_ptr<detail::registration> reg);
+        explicit scope(std::unique_ptr<detail::registration> reg);
         scope(scope const& other_);
         ~scope();
 

--- a/libs/luabind/src/class.cpp
+++ b/libs/luabind/src/class.cpp
@@ -235,7 +235,7 @@ namespace luabind { namespace detail {
     // -- interface ---------------------------------------------------------
 
     class_base::class_base(char const* name)
-        : scope(std::auto_ptr<registration>(
+        : scope(std::unique_ptr<registration>(
                 m_registration = new class_registration(name))
           )
     {
@@ -258,14 +258,14 @@ namespace luabind { namespace detail {
 
 	void class_base::add_member(registration* member)
 	{
-		std::auto_ptr<registration> ptr(member);
-		m_registration->m_members.operator,(scope(ptr));
+		std::unique_ptr<registration> ptr(member);
+		m_registration->m_members.operator,(scope(std::move(ptr)));
 	}
 
 	void class_base::add_default_member(registration* member)
 	{
-		std::auto_ptr<registration> ptr(member);
-		m_registration->m_default_members.operator,(scope(ptr));
+		std::unique_ptr<registration> ptr(member);
+		m_registration->m_default_members.operator,(scope(std::move(ptr)));
 	}
 
     const char* class_base::name() const 

--- a/libs/luabind/src/scope.cpp
+++ b/libs/luabind/src/scope.cpp
@@ -49,7 +49,8 @@ namespace luabind { namespace detail {
     {
     }
     
-    scope::scope(std::auto_ptr<detail::registration> reg)
+
+    scope::scope(std::unique_ptr<detail::registration> reg)
         : m_chain(reg.release())
     {
     }
@@ -193,7 +194,7 @@ namespace luabind {
     };
 
     namespace_::namespace_(char const* name)
-        : scope(std::auto_ptr<detail::registration>(
+        : scope(std::unique_ptr<detail::registration>(
               m_registration = new registration_(name)))
     {
     }

--- a/loginserver/encryption.cpp
+++ b/loginserver/encryption.cpp
@@ -16,6 +16,7 @@
 	along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 #include "encryption.h"
+#include "common/compiler_macros.h"
 
 #ifdef EQEMU_USE_OPENSSL
 #include <openssl/des.h>
@@ -137,7 +138,9 @@ const char *eqcrypt_block(const char *buffer_in, size_t buffer_in_sz, char *buff
 		return nullptr;
 	}
 
+	PUSH_DISABLE_DEPRECATED_WARNINGS()
 	DES_ncbc_encrypt((const unsigned char*)buffer_in, (unsigned char*)buffer_out, (long)buffer_in_sz, &k, &v, enc);
+	POP_DISABLE_DEPRECATED_WARNINGS()
 #endif
 	return buffer_out;
 }
@@ -164,7 +167,9 @@ std::string eqcrypt_md5(const std::string &msg)
 	unsigned char md5_digest[16];
 	char tmp[4];
 
+	PUSH_DISABLE_DEPRECATED_WARNINGS()
 	MD5((const unsigned char*)msg.c_str(), msg.length(), md5_digest);
+	POP_DISABLE_DEPRECATED_WARNINGS()
 
 	for (int i = 0; i < 16; ++i) {
 		sprintf(&tmp[0], "%02x", md5_digest[i]);

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -17,11 +17,13 @@
 */
 #ifdef EMBPERL
 
+#include "zone/embparser.h"
+
+#include "common/compiler_macros.h"
 #include "common/features.h"
 #include "common/misc_functions.h"
 #include "common/seperator.h"
 #include "common/strings.h"
-#include "zone/embparser.h"
 #include "zone/masterentity.h"
 #include "zone/qglobals.h"
 #include "zone/questmgr.h"
@@ -398,6 +400,8 @@ int PerlembParser::EventCommon(
 			zone
 		);
 	}
+
+	return 0;
 }
 
 int PerlembParser::EventNPC(
@@ -1211,31 +1215,33 @@ QuestType PerlembParser::GetQuestTypes(
 		event_id == EVENT_SPELL_EFFECT_TRANSLOCATE_COMPLETE
 	) {
 		return is_global ? QuestType::SpellGlobal : QuestType::Spell;
-	} else {
-		if (npc_mob) {
-			if (!inst) {
-				if (npc_mob->IsBot()) {
-					return is_global ? QuestType::BotGlobal : QuestType::Bot;
-				} else if (npc_mob->IsMerc()) {
-					return is_global ? QuestType::MercGlobal : QuestType::Merc;
-				} else if (npc_mob->IsNPC()) {
-					return is_global ? QuestType::NPCGlobal : QuestType::NPC;
-				}
-			} else {
-				return is_global ? QuestType::ItemGlobal : QuestType::Item;
-			}
-		} else if (!npc_mob && mob) {
-			if (!inst) {
-				if (mob->IsClient()) {
-					return is_global ? QuestType::PlayerGlobal : QuestType::Player;
-				}
-			} else {
-				return is_global ? QuestType::ItemGlobal : QuestType::Item;
-			}
-		} else if (zone) {
-			return is_global ? QuestType::ZoneGlobal : QuestType::Zone;
-		}
 	}
+
+	if (npc_mob) {
+		if (!inst) {
+			if (npc_mob->IsBot()) {
+				return is_global ? QuestType::BotGlobal : QuestType::Bot;
+			} else if (npc_mob->IsMerc()) {
+				return is_global ? QuestType::MercGlobal : QuestType::Merc;
+			} else if (npc_mob->IsNPC()) {
+				return is_global ? QuestType::NPCGlobal : QuestType::NPC;
+			}
+		} else {
+			return is_global ? QuestType::ItemGlobal : QuestType::Item;
+		}
+	} else if (mob) {
+		if (!inst) {
+			if (mob->IsClient()) {
+				return is_global ? QuestType::PlayerGlobal : QuestType::Player;
+			}
+		} else {
+			return is_global ? QuestType::ItemGlobal : QuestType::Item;
+		}
+	} else if (zone) {
+		return is_global ? QuestType::ZoneGlobal : QuestType::Zone;
+	}
+
+	UNREACHABLE();
 }
 
 std::string PerlembParser::GetQuestPackageName(

--- a/zone/lua_packet.cpp
+++ b/zone/lua_packet.cpp
@@ -82,6 +82,16 @@ Lua_Packet::Lua_Packet(const Lua_Packet& o) {
 	}
 }
 
+Lua_Packet::~Lua_Packet()
+{
+	if (owned_) {
+		EQApplicationPacket* ptr = GetLuaPtrData();
+		if (ptr) {
+			delete ptr;
+		}
+	}
+}
+
 int Lua_Packet::GetSize() {
 	Lua_Safe_Call_Int();
 	return static_cast<int>(self->size);

--- a/zone/lua_packet.h
+++ b/zone/lua_packet.h
@@ -41,7 +41,7 @@ public:
 	Lua_Packet(int opcode, int size, bool raw);
 	Lua_Packet& operator=(const Lua_Packet& o);
 	Lua_Packet(const Lua_Packet& o);
-	virtual ~Lua_Packet() { if(owned_) { EQApplicationPacket *ptr = GetLuaPtrData(); if(ptr) { delete ptr; } } }
+	virtual ~Lua_Packet();
 
 	int GetSize();
 	int GetOpcode();

--- a/zone/lua_ptr.h
+++ b/zone/lua_ptr.h
@@ -48,7 +48,8 @@ public:
 	Lua_Ptr(T *d) : d_(d) {
 	}
 	
-	~Lua_Ptr() {
+
+	virtual ~Lua_Ptr() {
 	}
 	
 	T *GetLuaPtrData() {


### PR DESCRIPTION
Fixed the warnings on the gcc side this time

- Disable deprecation warnings on openssl. Yes, we know, you don't want us to use "insecure" algorithms like DES and MD5 but we're going to do it anyways.
- Convert auto_ptr to unique_ptr and remove definition that makes auto_ptr available.
- Fix some cases of function not returning at the end
- Fix missing virtual destructor on Lua_Ptr and deletion of incomplete type in Lua_Packet