### PR TITLE
[Bots] Command add fix for spelltypeids/spelltypenames

### DIFF
--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -775,7 +775,7 @@ void helper_send_usage_required_bots(Client *bot_owner, uint16 spell_type)
 	bot_owner->Message(Chat::Green, "%s", description.c_str());
 }
 
-void SendSpellTypeWindow(Client* c, const Seperator* sep) {
+void SendSpellTypeWindow(Client* c, const Seperator* sep, bool short_names) {
 	std::string arg0 = sep->arg[0];
 	std::string arg1 = sep->arg[1];
 
@@ -828,7 +828,7 @@ void SendSpellTypeWindow(Client* c, const Seperator* sep) {
 	std::string popup_text = DialogueWindow::TableRow(
 		DialogueWindow::TableCell(DialogueWindow::ColorMessage(goldenrod, spell_type_field))
 		+
-		DialogueWindow::TableCell((!arg0.compare("^spelltypeids") ? DialogueWindow::ColorMessage(goldenrod, id_field) : DialogueWindow::ColorMessage(goldenrod, shortname_field)))
+		DialogueWindow::TableCell((!short_names ? DialogueWindow::ColorMessage(goldenrod, id_field) : DialogueWindow::ColorMessage(goldenrod, shortname_field)))
 	);
 
 	popup_text += DialogueWindow::TableRow(
@@ -845,7 +845,7 @@ void SendSpellTypeWindow(Client* c, const Seperator* sep) {
 		popup_text += DialogueWindow::TableRow(
 			DialogueWindow::TableCell(DialogueWindow::ColorMessage(forest_green, Bot::GetSpellTypeNameByID(i)))
 			+
-			DialogueWindow::TableCell((!arg0.compare("^spelltypeids") ? DialogueWindow::ColorMessage(slate_blue, std::to_string(i)) : DialogueWindow::ColorMessage(slate_blue, Bot::GetSpellTypeShortNameByID(i))))
+			DialogueWindow::TableCell((!short_names ? DialogueWindow::ColorMessage(slate_blue, std::to_string(i)) : DialogueWindow::ColorMessage(slate_blue, Bot::GetSpellTypeShortNameByID(i))))
 		);
 	}
 

--- a/zone/bot_command.h
+++ b/zone/bot_command.h
@@ -1182,4 +1182,4 @@ bool helper_is_help_or_usage(const char* arg);
 bool helper_no_available_bots(Client *bot_owner, Bot *my_bot = nullptr);
 void helper_send_available_subcommands(Client *bot_owner, const char* command_simile, std::vector<const char*> subcommand_list);
 void helper_send_usage_required_bots(Client *bot_owner, uint16 spell_type);
-void SendSpellTypeWindow(Client* c, const Seperator* sep);
+void SendSpellTypeWindow(Client* c, const Seperator* sep, bool short_names = false);

--- a/zone/bot_commands/bot_spelltypes.cpp
+++ b/zone/bot_commands/bot_spelltypes.cpp
@@ -24,5 +24,5 @@ void bot_command_spelltype_ids(Client* c, const Seperator* sep)
 
 void bot_command_spelltype_names(Client* c, const Seperator* sep)
 {
-	SendSpellTypeWindow(c, sep);
+	SendSpellTypeWindow(c, sep, true);
 }


### PR DESCRIPTION
# Description

Adds a bool pass to the `SendSpellTypeWindow` function to differentiate between the command calls for ids vs types.

Fixes # - #5065 & [Issues with Bot loading](https://discord.com/channels/1421535813031821376/1490493846700949695)

*Note: I was not able to reproduce this error before or after the change but this **should** satisfy the compiler to distinguish from the duplicate function calls for those having the issue.*

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Compiled, booted, tried all variants of the eligible ID ranges IE: `^spelltypeids 0-19` and `^spelltypenames 0-19` and displays properly.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
