### PR TITLE
strings: refactor Money and add MoneyShort

### DIFF
--- a/common/strings.cpp
+++ b/common/strings.cpp
@@ -380,118 +380,59 @@ std::string Strings::NumberToWords(unsigned long long int n)
 	return res;
 }
 
-std::string Strings::Money(uint64 platinum, uint64 gold, uint64 silver, uint64 copper)
-{
-	std::string money_string = "Unknown";
-	if (copper && silver && gold && platinum) { // CSGP
-		money_string = fmt::format(
-			"{} platinum, {} gold, {} silver, and {} copper",
-			Strings::Commify(std::to_string(platinum)),
-			Strings::Commify(std::to_string(gold)),
-			Strings::Commify(std::to_string(silver)),
-			Strings::Commify(std::to_string(copper))
-		);
+std::string Strings::Money(uint64 platinum, uint64 gold, uint64 silver, uint64 copper, bool commify) {
+	uint64 values[] = { platinum, gold, silver, copper };
+	const char* names[] = { " platinum", " gold", " silver", " copper" };
+
+	std::vector<std::string> parts;
+	for (int i = 0; i < 4; ++i) {
+		if (values[i] > 0) {
+			std::string s = std::to_string(values[i]);
+			parts.push_back((commify ? Strings::Commify(s) : s) + names[i]);
+		}
 	}
-	else if (copper && silver && !gold && platinum) { // CSP
-		money_string = fmt::format(
-			"{} platinum, {} silver, and {} copper",
-			Strings::Commify(std::to_string(platinum)),
-			Strings::Commify(std::to_string(silver)),
-			Strings::Commify(std::to_string(copper))
-		);
+
+	if (parts.empty()) return "0 copper";
+	if (parts.size() == 1) return parts[0];
+
+	std::string result;
+	for (size_t i = 0; i < parts.size(); ++i) {
+		result += parts[i];
+		if (i < parts.size() - 2) {
+			result += ", ";
+		}
+		else if (i == parts.size() - 2) {
+			// Oxford comma logic: ", and " for 3+ items, " and " for 2
+			result += (parts.size() > 2) ? ", and " : " and ";
+		}
 	}
-	else if (copper && silver && gold && !platinum) { // CSG
-		money_string = fmt::format(
-			"{} gold, {} silver, and {} copper",
-			Strings::Commify(std::to_string(gold)),
-			Strings::Commify(std::to_string(silver)),
-			Strings::Commify(std::to_string(copper))
-		);
-	}
-	else if (copper && !silver && !gold && platinum) { // CP
-		money_string = fmt::format(
-			"{} platinum and {} copper",
-			Strings::Commify(std::to_string(platinum)),
-			Strings::Commify(std::to_string(copper))
-		);
-	}
-	else if (copper && silver && !gold && !platinum) { // CS
-		money_string = fmt::format(
-			"{} silver and {} copper",
-			Strings::Commify(std::to_string(silver)),
-			Strings::Commify(std::to_string(copper))
-		);
-	}
-	else if (!copper && silver && gold && platinum) { // SGP
-		money_string = fmt::format(
-			"{} platinum, {} gold, and {} silver",
-			Strings::Commify(std::to_string(platinum)),
-			Strings::Commify(std::to_string(gold)),
-			Strings::Commify(std::to_string(silver))
-		);
-	}
-	else if (!copper && silver && !gold && platinum) { // SP
-		money_string = fmt::format(
-			"{} platinum and {} silver",
-			Strings::Commify(std::to_string(platinum)),
-			Strings::Commify(std::to_string(silver))
-		);
-	}
-	else if (!copper && silver && gold && !platinum) { // SG
-		money_string = fmt::format(
-			"{} gold and {} silver",
-			Strings::Commify(std::to_string(gold)),
-			Strings::Commify(std::to_string(silver))
-		);
-	}
-	else if (copper && !silver && gold && platinum) { // CGP
-		money_string = fmt::format(
-			"{} platinum, {} gold, and {} copper",
-			Strings::Commify(std::to_string(platinum)),
-			Strings::Commify(std::to_string(gold)),
-			Strings::Commify(std::to_string(copper))
-		);
-	}
-	else if (copper && !silver && gold && !platinum) { // CG
-		money_string = fmt::format(
-			"{} gold and {} copper",
-			Strings::Commify(std::to_string(gold)),
-			Strings::Commify(std::to_string(copper))
-		);
-	}
-	else if (!copper && !silver && gold && platinum) { // GP
-		money_string = fmt::format(
-			"{} platinum and {} gold",
-			Strings::Commify(std::to_string(platinum)),
-			Strings::Commify(std::to_string(gold))
-		);
-	}
-	else if (!copper && !silver && !gold && platinum) { // P
-		money_string = fmt::format(
-			"{} platinum",
-			Strings::Commify(std::to_string(platinum))
-		);
-	}
-	else if (!copper && !silver && gold && !platinum) { // G
-		money_string = fmt::format(
-			"{} gold",
-			Strings::Commify(std::to_string(gold))
-		);
-	}
-	else if (!copper && silver && !gold && !platinum) { // S
-		money_string = fmt::format(
-			"{} silver",
-			Strings::Commify(std::to_string(silver))
-		);
-	}
-	else if (copper && !silver && !gold && !platinum) { // C
-		money_string = fmt::format(
-			"{} copper",
-			Strings::Commify(std::to_string(copper))
-		);
-	}
-	return money_string;
+
+	return result;
 }
+
+std::string Strings::MoneyShort(uint64 copper, bool commify) {
+	// Matches merchant format
+	uint64 values[] = {
+		copper / 1000,
+		(copper / 100) % 10,
+		(copper / 10) % 10,
+		copper % 10
+	};
+	const char* names[] = { " platinum", " gold", " silver", " copper" };
+
+	std::string result;
+	for (int i = 0; i < 4; ++i) {
+		if (values[i] > 0) {
+			if (!result.empty()) result += " ";
+
+			std::string s = std::to_string(values[i]);
+			result += (commify ? Strings::Commify(s) : s) + names[i];
+		}
+	}
+
+	return result.empty() ? "0 copper" : result;
+}
+
 std::string Strings::SecondsToTime(int duration, bool is_milliseconds)
 {
 	if (duration <= 0) {

--- a/common/strings.h
+++ b/common/strings.h
@@ -62,7 +62,8 @@ public:
 	static std::string Join(const std::vector<std::string> &ar, const std::string &delim);
 	static std::string Join(const std::vector<uint32_t> &ar, const std::string &delim);
 	static std::string MillisecondsToTime(int duration);
-	static std::string Money(uint64 platinum, uint64 gold = 0, uint64 silver = 0, uint64 copper = 0);
+	static std::string Money(uint64 platinum, uint64 gold = 0, uint64 silver = 0, uint64 copper = 0, bool commify = true);
+	static std::string MoneyShort(uint64 copper = 0, bool commify = true); // Matches merchant format when commify is false
 	static std::string NumberToWords(unsigned long long int n);
 	static std::string Repeat(std::string s, int n);
 	static std::string Replace(std::string subject, const std::string &search, const std::string &replace);


### PR DESCRIPTION
# Description

Implementing a method to match the merchant's short, no-comma format.  Cleaned up the existing long form in the process.  Added an optional commify arg for commas, defaults true so as not to break existing functionality.  The motivation arose from batch selling items and needing to manually print the merchant message.  Also changed the existing "Unknown" result to "0 copper".

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

<img width="471" height="126" alt="bulk money short" src="https://github.com/user-attachments/assets/ae877f86-cecd-40e5-9aee-57a840a22327" />

When 1-click bulk selling all items in a bag, I'm iterating and calling MoneyShort on each.

## Clients tested:

RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [x] I own the changes of my code and take responsibility for the potential issues that occur
