### PR TITLE
Updated the database scripts and re-synced the database bindings

### DIFF
--- a/common/database/database_update.cpp
+++ b/common/database/database_update.cpp
@@ -28,6 +28,7 @@
 #include "common/strings.h"
 
 #include <filesystem>
+#include <ranges>
 
 
 constexpr int BREAK_LENGTH = 70;
@@ -73,35 +74,38 @@ void DatabaseUpdate::CheckDbUpdates()
 		return;
 	}
 
-	if (UpdateManifest(manifest_entries, v.server_database_version, b.server_database_version)) {
+	int server_database_version = UpdateManifest(manifest_entries, v.server_database_version, b.server_database_version);
+	if (server_database_version > v.server_database_version) {
 		LogInfo(
 			"Updates ran successfully, setting database version to [{}] from [{}]",
-			b.server_database_version,
+			server_database_version,
 			v.server_database_version
 		);
-		m_database->QueryDatabase(fmt::format("UPDATE `db_version` SET `version` = {}", b.server_database_version));
+		m_database->QueryDatabase(fmt::format("UPDATE `db_version` SET `version` = {}", server_database_version));
 	}
 
-	if (UpdateManifest(manifest_entries_custom, v.custom_database_version, b.custom_database_version)) {
+	int custom_database_version = UpdateManifest(manifest_entries_custom, v.custom_database_version, b.custom_database_version);
+	if (custom_database_version > v.server_database_version) {
 		LogInfo(
 			"Updates ran successfully, setting database version to [{}] from [{}]",
-			b.custom_database_version,
+			custom_database_version,
 			v.custom_database_version
 		);
-		m_database->QueryDatabase(fmt::format("UPDATE `db_version` SET `custom_version` = {}", b.custom_database_version));
+		m_database->QueryDatabase(fmt::format("UPDATE `db_version` SET `custom_version` = {}", custom_database_version));
 	}
 
 	if (b.bots_database_version > 0) {
-		if (UpdateManifest(bot_manifest_entries, v.bots_database_version, b.bots_database_version)) {
+		int bots_database_version = UpdateManifest(bot_manifest_entries, v.bots_database_version, b.bots_database_version);
+		if (bots_database_version > v.bots_database_version) {
 			LogInfo(
 				"Updates ran successfully, setting database version to [{}] from [{}]",
-				b.bots_database_version,
+				bots_database_version,
 				v.bots_database_version
 			);
 			m_database->QueryDatabase(
 				fmt::format(
 					"UPDATE `db_version` SET `bots_version` = {}",
-					b.bots_database_version
+					bots_database_version
 				)
 			);
 		}
@@ -131,7 +135,7 @@ std::string DatabaseUpdate::GetQueryResult(const ManifestEntry& e)
 	return Strings::Join(result_lines, "\n");
 }
 
-bool DatabaseUpdate::ShouldRunMigration(ManifestEntry &e, std::string query_result)
+bool DatabaseUpdate::ShouldRunMigration(const ManifestEntry& e, std::string& query_result)
 {
 	std::string r = Strings::Trim(query_result);
 	if (e.condition == "contains") {
@@ -163,53 +167,52 @@ bool is_atty()
 #endif
 }
 
-// return true if we ran updates
-bool DatabaseUpdate::UpdateManifest(
-	std::vector<ManifestEntry> entries,
+std::string DisplayPrompt(const std::string& prompt)
+{
+	std::string input;
+	if (is_atty()) {
+		LogInfo("{} (Timeout 60s)", prompt);
+
+		// user input
+		bool gave_input = false;
+		time_t start_time = time(nullptr);
+		time_t wait_time_seconds = 60;
+
+		// spawn a concurrent thread that waits for input from std::cin
+		std::thread t1(
+			[&]() {
+				std::cin >> input;
+				gave_input = true;
+			}
+		);
+		t1.detach();
+
+		// check the inputReceived flag once every 50ms for 10 seconds
+		while (time(nullptr) < start_time + wait_time_seconds && !gave_input) {
+			std::this_thread::sleep_for(std::chrono::milliseconds(50));
+		}
+	}
+
+	return Strings::Trim(input);
+}
+
+// return last successful version updated
+int DatabaseUpdate::UpdateManifest(
+	std::vector<ManifestEntry>& entries,
 	int version_low,
 	int version_high
 )
 {
-	std::vector<int> missing_migrations = {};
+	int latest_version = version_low;
 	if (version_low != version_high) {
+		// assume at this point that we have a migration to do because there is a version number difference. If a
+		// migration for a specific manifest entry does not happen because of a missing test, then log it and
+		// continue (the assumption here is that the user has manually fixed the database at this point). If a force
+		// interactive flag is set, then stop for each query. Fail the migration if the user says no or it times out
+		// because it means the database isn't going to have a correct state to continue. Start with backing up the
+		// database as per user options.
 
-		EQEmuLogSys::Instance()->DisableMySQLErrorLogs();
-		bool force_interactive = false;
-		for (int version = version_low + 1; version <= version_high; ++version) {
-			for (auto &e: entries) {
-				if (e.version == version) {
-					bool        has_migration = true;
-					std::string r             = GetQueryResult(e);
-					if (ShouldRunMigration(e, r)) {
-						has_migration = false;
-						missing_migrations.emplace_back(e.version);
-					}
-
-					std::string prefix = fmt::format(
-						"[{}]",
-						has_migration ? "ok" : "missing"
-					);
-
-					LogInfo(
-						"[{}] {:>10} | [{}]",
-						e.version,
-						prefix,
-						e.description
-					);
-
-					if (!has_migration && e.force_interactive) {
-						force_interactive = true;
-					}
-				}
-			}
-		}
-		EQEmuLogSys::Instance()->EnableMySQLErrorLogs();
-		LogInfo("{}", Strings::Repeat("-", BREAK_LENGTH));
-
-		if (!missing_migrations.empty() && m_skip_backup) {
-			LogInfo("Skipping database backup");
-		}
-		else if (!missing_migrations.empty()) {
+		if (!m_skip_backup) {
 			LogInfo("Automatically backing up database before applying updates");
 			LogInfo("{}", Strings::Repeat("-", BREAK_LENGTH));
 			auto s = DatabaseDumpService();
@@ -217,120 +220,73 @@ bool DatabaseUpdate::UpdateManifest(
 			s.SetDumpWithCompression(true);
 			s.DatabaseDump();
 			LogInfo("{}", Strings::Repeat("-", BREAK_LENGTH));
+		} else {
+			LogInfo("Skipping database backup");
 		}
 
-		if (!missing_migrations.empty()) {
-			LogInfo("Running database migrations. Please wait...");
-			LogInfo("{}", Strings::Repeat("-", BREAK_LENGTH));
-		}
+		LogInfo("Running database migrations. Please wait...");
+		LogInfo("{}", Strings::Repeat("-", BREAK_LENGTH));
 
-		if (force_interactive && !std::getenv("FORCE_INTERACTIVE")) {
-			LogInfo("{}", Strings::Repeat("-", BREAK_LENGTH));
-			LogInfo("Some migrations require user input. Running interactively");
-			LogInfo("This is usually due to a major change that could cause data loss");
-			LogInfo("Your server is automatically backed up before these updates are applied");
-			LogInfo("but you should also make sure you take a backup prior to running this update");
-			LogInfo("Would you like to run this update? [y/n] (Timeout 60s)");
-			LogInfo("{}", Strings::Repeat("-", BREAK_LENGTH));
+		auto filtered_entries = entries | std::views::filter(
+			[version_low, version_high](const ManifestEntry& entry)
+			{ return entry.version > version_low && entry.version <= version_high; });
 
-			// user input
-			std::string input;
-			bool        gave_input        = false;
-			time_t      start_time        = time(nullptr);
-			time_t      wait_time_seconds = 60;
+		std::vector<ManifestEntry> sorted_entries{filtered_entries.begin(), filtered_entries.end()};
+		std::ranges::sort(sorted_entries, {}, &ManifestEntry::version);
 
-			// spawn a concurrent thread that waits for input from std::cin
-			std::thread t1(
-				[&]() {
-					std::cin >> input;
-					gave_input = true;
-				}
-			);
-			t1.detach();
+		for (const auto& entry : sorted_entries) {
+			// this is the test to run this individual migration. If the test fails, then it is safe to assume
+			// that this migration has already happened manually or otherwise and it's safe to skip
+			// suppress error messages here, it's all tested in the following function
+			EQEmuLogSys::Instance()->DisableMySQLErrorLogs();
+			std::string result = GetQueryResult(entry);
+			EQEmuLogSys::Instance()->EnableMySQLErrorLogs();
 
-			// check the inputReceived flag once every 50ms for 10 seconds
-			while (time(nullptr) < start_time + wait_time_seconds && !gave_input) {
-				std::this_thread::sleep_for(std::chrono::milliseconds(50));
-			}
+			if (ShouldRunMigration(entry, result)) {
+				if (entry.force_interactive && !std::getenv("FORCE_INTERACTIVE")) {
+					LogInfo("{}", Strings::Repeat("-", BREAK_LENGTH));
+					LogInfo("This migration requires user input. Running interactively");
+					LogInfo("This is usually due to a major change that could cause data loss");
+					LogInfo("Your server is automatically backed up before these updates are applied");
+					LogInfo("but you should also make sure you take a backup prior to running this update");
+					LogInfo("{}", Strings::Repeat("-", BREAK_LENGTH));
 
-			// prompt for user skip
-			if (Strings::Trim(input) != "y") {
-				LogInfo("Exiting due to user input");
-				std::exit(1);
-			}
-		}
-
-		for (auto &m: missing_migrations) {
-			for (auto &e: entries) {
-				if (e.version == m) {
-					bool errored_migration = false;
-
-					auto r = (e.content_schema_update ? m_content_database : m_database)->QueryDatabaseMulti(e.sql);
-
-					// ignore empty query result "errors"
-					if (r.ErrorNumber() != 1065 && !r.ErrorMessage().empty()) {
-						LogError("(#{}) [{}]", r.ErrorNumber(), r.ErrorMessage());
-						errored_migration = true;
-
-						LogInfo("Required database update failed. This could be a problem");
-
-						// if terminal attached then prompt for skip
-						if (is_atty()) {
-							LogInfo("Would you like to skip this update? [y/n] (Timeout 60s)");
-
-							// user input
-							std::string input;
-							bool        gave_input        = false;
-							time_t      start_time        = time(nullptr);
-							time_t      wait_time_seconds = 60;
-
-							// spawn a concurrent thread that waits for input from std::cin
-							std::thread t1(
-								[&]() {
-									std::cin >> input;
-									gave_input = true;
-								}
-							);
-							t1.detach();
-
-							// check the inputReceived flag once every 50ms for 10 seconds
-							while (time(nullptr) < start_time + wait_time_seconds && !gave_input) {
-								std::this_thread::sleep_for(std::chrono::milliseconds(50));
-							}
-
-							// prompt for user skip
-							if (Strings::Trim(input) == "y") {
-								errored_migration = false;
-								LogInfo("Skipping update [{}] [{}]", e.version, e.description);
-							}
-						} else {
-							errored_migration = true;
-							LogInfo("Skipping update [{}] [{}]", e.version, e.description);
-						}
+					// prompt for user skip
+					if (DisplayPrompt("Would you like to run this update? [y/n]") != "y") {
+						LogInfo("Exiting due to user input");
+						return latest_version;
 					}
+				}
 
-					LogInfo(
-						"[{}] [{}] [{}]",
-						e.version,
-						e.description,
-						(errored_migration ? "error" : "ok")
-					);
+				auto r = (entry.content_schema_update ? m_content_database : m_database)->QueryDatabaseMulti(entry.sql);
 
-					if (errored_migration) {
-						LogError("Fatal | Database migration [{}] failed to run", e.description);
+				// ignore empty query result "errors"
+				if (r.ErrorNumber() != 1065 && !r.ErrorMessage().empty()) {
+					LogError("(#{}) [{}]", r.ErrorNumber(), r.ErrorMessage());
+					LogInfo("Required database update failed.");
+
+					// if terminal attached then prompt for skip
+					if (DisplayPrompt("Would you like to skip this update? [y/n]") == "y") {
+						LogInfo("Skipping update [{}] [{}]", entry.version, entry.description);
+					} else {
+						LogError("Fatal | Database migration [{}] failed to run", entry.description);
 						LogError("Fatal | Shutting down");
-						std::exit(1);
+						return latest_version;
 					}
+
+					LogInfo("[{}] [{}] [error]", entry.version, entry.description);
+				} else {
+					LogInfo("[{}] [{}] [ok]", entry.version, entry.description);
 				}
+
+				latest_version = entry.version;
 			}
 		}
 
 		LogInfo("{}", Strings::Repeat("-", BREAK_LENGTH));
-
-		return true;
 	}
 
-	return false;
+	return latest_version;
 }
 
 DatabaseUpdate *DatabaseUpdate::SetDatabase(Database *db)

--- a/common/database/database_update.h
+++ b/common/database/database_update.h
@@ -42,8 +42,8 @@ public:
 	DatabaseVersion GetBinaryDatabaseVersions();
 	void CheckDbUpdates();
 	std::string GetQueryResult(const ManifestEntry& e);
-	static bool ShouldRunMigration(ManifestEntry &e, std::string query_result);
-	bool UpdateManifest(std::vector<ManifestEntry> entries, int version_low, int version_high);
+	static bool ShouldRunMigration(const ManifestEntry& e, std::string& query_result);
+	int UpdateManifest(std::vector<ManifestEntry>& entries, int version_low, int version_high);
 
 	DatabaseUpdate *SetDatabase(Database *db);
 	DatabaseUpdate *SetContentDatabase(Database *db);

--- a/common/repositories/base/base_adventure_template_repository.h
+++ b/common/repositories/base/base_adventure_template_repository.h
@@ -23,7 +23,7 @@
  * Any modifications to base repositories are to be made by the generator only
  *
  * @generator ./utils/scripts/generators/repository-generator.pl
- * @docs https://docs.eqemu.io/developer/repositories
+ * @docs https://docs.eqemu.dev/developer/repositories
  */
 
 #pragma once
@@ -68,7 +68,7 @@ public:
 		float       graveyard_x;
 		float       graveyard_y;
 		float       graveyard_z;
-		std::string graveyard_radius;
+		float       graveyard_radius;
 	};
 
 	static std::string PrimaryKey()
@@ -292,6 +292,7 @@ public:
 			e.graveyard_x       = row[29] ? strtof(row[29], nullptr) : 0;
 			e.graveyard_y       = row[30] ? strtof(row[30], nullptr) : 0;
 			e.graveyard_z       = row[31] ? strtof(row[31], nullptr) : 0;
+			e.graveyard_radius  = row[32] ? (strtof(row[32], nullptr) > 0.0f ? strtof(row[32], nullptr) : 0) : 0;
 
 			return e;
 		}
@@ -539,6 +540,7 @@ public:
 			e.graveyard_x       = row[29] ? strtof(row[29], nullptr) : 0;
 			e.graveyard_y       = row[30] ? strtof(row[30], nullptr) : 0;
 			e.graveyard_z       = row[31] ? strtof(row[31], nullptr) : 0;
+			e.graveyard_radius  = row[32] ? (strtof(row[32], nullptr) > 0.0f ? strtof(row[32], nullptr) : 0) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -595,6 +597,7 @@ public:
 			e.graveyard_x       = row[29] ? strtof(row[29], nullptr) : 0;
 			e.graveyard_y       = row[30] ? strtof(row[30], nullptr) : 0;
 			e.graveyard_z       = row[31] ? strtof(row[31], nullptr) : 0;
+			e.graveyard_radius  = row[32] ? (strtof(row[32], nullptr) > 0.0f ? strtof(row[32], nullptr) : 0) : 0;
 
 			all_entries.push_back(e);
 		}

--- a/common/repositories/base/base_blocked_spells_repository.h
+++ b/common/repositories/base/base_blocked_spells_repository.h
@@ -193,7 +193,7 @@ public:
 			BlockedSpells e{};
 
 			e.id                     = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
-			e.spellid                = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.spellid                = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
 			e.type                   = row[2] ? static_cast<int8_t>(atoi(row[2])) : 0;
 			e.zoneid                 = row[3] ? static_cast<int32_t>(atoi(row[3])) : 0;
 			e.x                      = row[4] ? strtof(row[4], nullptr) : 0;
@@ -372,7 +372,7 @@ public:
 			BlockedSpells e{};
 
 			e.id                     = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
-			e.spellid                = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.spellid                = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
 			e.type                   = row[2] ? static_cast<int8_t>(atoi(row[2])) : 0;
 			e.zoneid                 = row[3] ? static_cast<int32_t>(atoi(row[3])) : 0;
 			e.x                      = row[4] ? strtof(row[4], nullptr) : 0;
@@ -412,7 +412,7 @@ public:
 			BlockedSpells e{};
 
 			e.id                     = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
-			e.spellid                = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.spellid                = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
 			e.type                   = row[2] ? static_cast<int8_t>(atoi(row[2])) : 0;
 			e.zoneid                 = row[3] ? static_cast<int32_t>(atoi(row[3])) : 0;
 			e.x                      = row[4] ? strtof(row[4], nullptr) : 0;

--- a/common/repositories/base/base_bot_blocked_buffs_repository.h
+++ b/common/repositories/base/base_bot_blocked_buffs_repository.h
@@ -144,10 +144,10 @@ public:
 		if (results.RowCount() == 1) {
 			BotBlockedBuffs e{};
 
-			e.bot_id      = row[0] ? static_cast<uint32_t>(atoi(row[0])) : 0;
-			e.spell_id    = row[1] ? static_cast<uint32_t>(atoi(row[1])) : 0;
-			e.blocked     = row[2] ? static_cast<uint8_t>(atoi(row[2])) : 0;
-			e.blocked_pet = row[3] ? static_cast<uint8_t>(atoi(row[3])) : 0;
+			e.bot_id      = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.spell_id    = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
+			e.blocked     = row[2] ? static_cast<uint8_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.blocked_pet = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 
 			return e;
 		}
@@ -276,10 +276,10 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			BotBlockedBuffs e{};
 
-			e.bot_id      = row[0] ? static_cast<uint32_t>(atoi(row[0])) : 0;
-			e.spell_id    = row[1] ? static_cast<uint32_t>(atoi(row[1])) : 0;
-			e.blocked     = row[2] ? static_cast<uint8_t>(atoi(row[2])) : 0;
-			e.blocked_pet = row[3] ? static_cast<uint8_t>(atoi(row[3])) : 0;
+			e.bot_id      = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.spell_id    = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
+			e.blocked     = row[2] ? static_cast<uint8_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.blocked_pet = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -304,10 +304,10 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			BotBlockedBuffs e{};
 
-			e.bot_id      = row[0] ? static_cast<uint32_t>(atoi(row[0])) : 0;
-			e.spell_id    = row[1] ? static_cast<uint32_t>(atoi(row[1])) : 0;
-			e.blocked     = row[2] ? static_cast<uint8_t>(atoi(row[2])) : 0;
-			e.blocked_pet = row[3] ? static_cast<uint8_t>(atoi(row[3])) : 0;
+			e.bot_id      = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.spell_id    = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
+			e.blocked     = row[2] ? static_cast<uint8_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.blocked_pet = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
 		}

--- a/common/repositories/base/base_bot_buffs_repository.h
+++ b/common/repositories/base/base_bot_buffs_repository.h
@@ -210,7 +210,7 @@ public:
 
 			e.buffs_index         = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.bot_id              = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.spell_id            = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id            = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.caster_level        = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.duration_formula    = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.tics_remaining      = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;
@@ -405,7 +405,7 @@ public:
 
 			e.buffs_index         = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.bot_id              = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.spell_id            = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id            = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.caster_level        = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.duration_formula    = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.tics_remaining      = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;
@@ -449,7 +449,7 @@ public:
 
 			e.buffs_index         = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.bot_id              = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.spell_id            = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id            = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.caster_level        = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.duration_formula    = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.tics_remaining      = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;

--- a/common/repositories/base/base_bot_create_combinations_repository.h
+++ b/common/repositories/base/base_bot_create_combinations_repository.h
@@ -32,6 +32,7 @@
 #include "common/strings.h"
 
 #include <ctime>
+
 class BaseBotCreateCombinationsRepository {
 public:
 	struct BotCreateCombinations {

--- a/common/repositories/base/base_bot_heal_rotations_repository.h
+++ b/common/repositories/base/base_bot_heal_rotations_repository.h
@@ -198,6 +198,16 @@ public:
 			e.fast_heals          = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.adaptive_targeting  = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.casting_override    = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;
+			e.safe_hp_base        = row[6] ? (strtof(row[6], nullptr) > 0.0f ? strtof(row[6], nullptr) : 0) : 0;
+			e.safe_hp_cloth       = row[7] ? (strtof(row[7], nullptr) > 0.0f ? strtof(row[7], nullptr) : 0) : 0;
+			e.safe_hp_leather     = row[8] ? (strtof(row[8], nullptr) > 0.0f ? strtof(row[8], nullptr) : 0) : 0;
+			e.safe_hp_chain       = row[9] ? (strtof(row[9], nullptr) > 0.0f ? strtof(row[9], nullptr) : 0) : 0;
+			e.safe_hp_plate       = row[10] ? (strtof(row[10], nullptr) > 0.0f ? strtof(row[10], nullptr) : 0) : 0;
+			e.critical_hp_base    = row[11] ? (strtof(row[11], nullptr) > 0.0f ? strtof(row[11], nullptr) : 0) : 0;
+			e.critical_hp_cloth   = row[12] ? (strtof(row[12], nullptr) > 0.0f ? strtof(row[12], nullptr) : 0) : 0;
+			e.critical_hp_leather = row[13] ? (strtof(row[13], nullptr) > 0.0f ? strtof(row[13], nullptr) : 0) : 0;
+			e.critical_hp_chain   = row[14] ? (strtof(row[14], nullptr) > 0.0f ? strtof(row[14], nullptr) : 0) : 0;
+			e.critical_hp_plate   = row[15] ? (strtof(row[15], nullptr) > 0.0f ? strtof(row[15], nullptr) : 0) : 0;
 
 			return e;
 		}
@@ -367,6 +377,16 @@ public:
 			e.fast_heals          = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.adaptive_targeting  = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.casting_override    = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;
+			e.safe_hp_base        = row[6] ? (strtof(row[6], nullptr) > 0.0f ? strtof(row[6], nullptr) : 0) : 0;
+			e.safe_hp_cloth       = row[7] ? (strtof(row[7], nullptr) > 0.0f ? strtof(row[7], nullptr) : 0) : 0;
+			e.safe_hp_leather     = row[8] ? (strtof(row[8], nullptr) > 0.0f ? strtof(row[8], nullptr) : 0) : 0;
+			e.safe_hp_chain       = row[9] ? (strtof(row[9], nullptr) > 0.0f ? strtof(row[9], nullptr) : 0) : 0;
+			e.safe_hp_plate       = row[10] ? (strtof(row[10], nullptr) > 0.0f ? strtof(row[10], nullptr) : 0) : 0;
+			e.critical_hp_base    = row[11] ? (strtof(row[11], nullptr) > 0.0f ? strtof(row[11], nullptr) : 0) : 0;
+			e.critical_hp_cloth   = row[12] ? (strtof(row[12], nullptr) > 0.0f ? strtof(row[12], nullptr) : 0) : 0;
+			e.critical_hp_leather = row[13] ? (strtof(row[13], nullptr) > 0.0f ? strtof(row[13], nullptr) : 0) : 0;
+			e.critical_hp_chain   = row[14] ? (strtof(row[14], nullptr) > 0.0f ? strtof(row[14], nullptr) : 0) : 0;
+			e.critical_hp_plate   = row[15] ? (strtof(row[15], nullptr) > 0.0f ? strtof(row[15], nullptr) : 0) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -397,6 +417,16 @@ public:
 			e.fast_heals          = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.adaptive_targeting  = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.casting_override    = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;
+			e.safe_hp_base        = row[6] ? (strtof(row[6], nullptr) > 0.0f ? strtof(row[6], nullptr) : 0) : 0;
+			e.safe_hp_cloth       = row[7] ? (strtof(row[7], nullptr) > 0.0f ? strtof(row[7], nullptr) : 0) : 0;
+			e.safe_hp_leather     = row[8] ? (strtof(row[8], nullptr) > 0.0f ? strtof(row[8], nullptr) : 0) : 0;
+			e.safe_hp_chain       = row[9] ? (strtof(row[9], nullptr) > 0.0f ? strtof(row[9], nullptr) : 0) : 0;
+			e.safe_hp_plate       = row[10] ? (strtof(row[10], nullptr) > 0.0f ? strtof(row[10], nullptr) : 0) : 0;
+			e.critical_hp_base    = row[11] ? (strtof(row[11], nullptr) > 0.0f ? strtof(row[11], nullptr) : 0) : 0;
+			e.critical_hp_cloth   = row[12] ? (strtof(row[12], nullptr) > 0.0f ? strtof(row[12], nullptr) : 0) : 0;
+			e.critical_hp_leather = row[13] ? (strtof(row[13], nullptr) > 0.0f ? strtof(row[13], nullptr) : 0) : 0;
+			e.critical_hp_chain   = row[14] ? (strtof(row[14], nullptr) > 0.0f ? strtof(row[14], nullptr) : 0) : 0;
+			e.critical_hp_plate   = row[15] ? (strtof(row[15], nullptr) > 0.0f ? strtof(row[15], nullptr) : 0) : 0;
 
 			all_entries.push_back(e);
 		}

--- a/common/repositories/base/base_bot_inspect_messages_repository.h
+++ b/common/repositories/base/base_bot_inspect_messages_repository.h
@@ -32,6 +32,7 @@
 #include "common/strings.h"
 
 #include <ctime>
+
 class BaseBotInspectMessagesRepository {
 public:
 	struct BotInspectMessages {

--- a/common/repositories/base/base_bot_pet_buffs_repository.h
+++ b/common/repositories/base/base_bot_pet_buffs_repository.h
@@ -150,7 +150,7 @@ public:
 
 			e.pet_buffs_index = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.pets_index      = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.spell_id        = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id        = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.caster_level    = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.duration        = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 
@@ -285,7 +285,7 @@ public:
 
 			e.pet_buffs_index = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.pets_index      = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.spell_id        = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id        = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.caster_level    = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.duration        = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 
@@ -314,7 +314,7 @@ public:
 
 			e.pet_buffs_index = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.pets_index      = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.spell_id        = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id        = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.caster_level    = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.duration        = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 

--- a/common/repositories/base/base_bot_pets_repository.h
+++ b/common/repositories/base/base_bot_pets_repository.h
@@ -153,7 +153,7 @@ public:
 			BotPets e{};
 
 			e.pets_index = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
-			e.spell_id   = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.spell_id   = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
 			e.bot_id     = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.name       = row[3] ? row[3] : "";
 			e.mana       = row[4] ? static_cast<int32_t>(atoi(row[4])) : 0;
@@ -292,7 +292,7 @@ public:
 			BotPets e{};
 
 			e.pets_index = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
-			e.spell_id   = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.spell_id   = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
 			e.bot_id     = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.name       = row[3] ? row[3] : "";
 			e.mana       = row[4] ? static_cast<int32_t>(atoi(row[4])) : 0;
@@ -322,7 +322,7 @@ public:
 			BotPets e{};
 
 			e.pets_index = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
-			e.spell_id   = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.spell_id   = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
 			e.bot_id     = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.name       = row[3] ? row[3] : "";
 			e.mana       = row[4] ? static_cast<int32_t>(atoi(row[4])) : 0;

--- a/common/repositories/base/base_bot_settings_repository.h
+++ b/common/repositories/base/base_bot_settings_repository.h
@@ -41,7 +41,7 @@ public:
 		uint8_t     stance;
 		uint16_t    setting_id;
 		uint8_t     setting_type;
-		int32_t     value;
+		int64_t     value;
 		std::string category_name;
 		std::string setting_name;
 	};
@@ -116,7 +116,7 @@ public:
 	{
 		BotSettings e{};
 
-		e.character_id	= 0;
+		e.character_id  = 0;
 		e.bot_id        = 0;
 		e.stance        = 0;
 		e.setting_id    = 0;
@@ -160,12 +160,12 @@ public:
 		if (results.RowCount() == 1) {
 			BotSettings e{};
 
-			e.character_id	= row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.character_id  = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.bot_id        = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
 			e.stance        = row[2] ? static_cast<uint8_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.setting_id    = row[3] ? static_cast<uint16_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.setting_type  = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
-			e.value         = row[5] ? static_cast<int32_t>(atoi(row[5])) : 0;
+			e.value         = row[5] ? strtoll(row[5], nullptr, 10) : 0;
 			e.category_name = row[6] ? row[6] : "";
 			e.setting_name  = row[7] ? row[7] : "";
 
@@ -308,12 +308,12 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			BotSettings e{};
 
-			e.character_id	= row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.character_id  = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.bot_id        = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
 			e.stance        = row[2] ? static_cast<uint8_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.setting_id    = row[3] ? static_cast<uint16_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.setting_type  = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
-			e.value         = row[5] ? static_cast<int32_t>(atoi(row[5])) : 0;
+			e.value         = row[5] ? strtoll(row[5], nullptr, 10) : 0;
 			e.category_name = row[6] ? row[6] : "";
 			e.setting_name  = row[7] ? row[7] : "";
 
@@ -340,12 +340,12 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			BotSettings e{};
 
-			e.character_id	= row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.character_id  = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.bot_id        = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
 			e.stance        = row[2] ? static_cast<uint8_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.setting_id    = row[3] ? static_cast<uint16_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.setting_type  = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
-			e.value         = row[5] ? static_cast<int32_t>(atoi(row[5])) : 0;
+			e.value         = row[5] ? strtoll(row[5], nullptr, 10) : 0;
 			e.category_name = row[6] ? row[6] : "";
 			e.setting_name  = row[7] ? row[7] : "";
 

--- a/common/repositories/base/base_bot_spell_settings_repository.h
+++ b/common/repositories/base/base_bot_spell_settings_repository.h
@@ -158,7 +158,7 @@ public:
 
 			e.id         = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.bot_id     = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.spell_id   = row[2] ? static_cast<int16_t>(atoi(row[2])) : 0;
+			e.spell_id   = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.priority   = row[3] ? static_cast<int16_t>(atoi(row[3])) : 0;
 			e.min_hp     = row[4] ? static_cast<int16_t>(atoi(row[4])) : 0;
 			e.max_hp     = row[5] ? static_cast<int16_t>(atoi(row[5])) : 0;
@@ -301,7 +301,7 @@ public:
 
 			e.id         = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.bot_id     = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.spell_id   = row[2] ? static_cast<int16_t>(atoi(row[2])) : 0;
+			e.spell_id   = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.priority   = row[3] ? static_cast<int16_t>(atoi(row[3])) : 0;
 			e.min_hp     = row[4] ? static_cast<int16_t>(atoi(row[4])) : 0;
 			e.max_hp     = row[5] ? static_cast<int16_t>(atoi(row[5])) : 0;
@@ -332,7 +332,7 @@ public:
 
 			e.id         = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.bot_id     = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.spell_id   = row[2] ? static_cast<int16_t>(atoi(row[2])) : 0;
+			e.spell_id   = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.priority   = row[3] ? static_cast<int16_t>(atoi(row[3])) : 0;
 			e.min_hp     = row[4] ? static_cast<int16_t>(atoi(row[4])) : 0;
 			e.max_hp     = row[5] ? static_cast<int16_t>(atoi(row[5])) : 0;

--- a/common/repositories/base/base_bot_spells_entries_repository.h
+++ b/common/repositories/base/base_bot_spells_entries_repository.h
@@ -190,7 +190,7 @@ public:
 
 			e.id                = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.npc_spells_id     = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.spell_id          = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id          = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.type              = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.minlevel          = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.maxlevel          = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 255;
@@ -365,7 +365,7 @@ public:
 
 			e.id                = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.npc_spells_id     = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.spell_id          = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id          = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.type              = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.minlevel          = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.maxlevel          = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 255;
@@ -404,7 +404,7 @@ public:
 
 			e.id                = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.npc_spells_id     = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.spell_id          = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id          = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.type              = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.minlevel          = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.maxlevel          = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 255;

--- a/common/repositories/base/base_bot_timers_repository.h
+++ b/common/repositories/base/base_bot_timers_repository.h
@@ -170,7 +170,7 @@ public:
 			e.recast_time = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.is_spell    = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.is_disc     = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 0;
-			e.spell_id    = row[6] ? static_cast<uint32_t>(strtoul(row[6], nullptr, 10)) : 0;
+			e.spell_id    = row[6] ? static_cast<int32_t>(atoi(row[6])) : 0;
 			e.is_item     = row[7] ? static_cast<uint8_t>(strtoul(row[7], nullptr, 10)) : 0;
 			e.item_id     = row[8] ? static_cast<uint32_t>(strtoul(row[8], nullptr, 10)) : 0;
 
@@ -322,7 +322,7 @@ public:
 			e.recast_time = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.is_spell    = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.is_disc     = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 0;
-			e.spell_id    = row[6] ? static_cast<uint32_t>(strtoul(row[6], nullptr, 10)) : 0;
+			e.spell_id    = row[6] ? static_cast<int32_t>(atoi(row[6])) : 0;
 			e.is_item     = row[7] ? static_cast<uint8_t>(strtoul(row[7], nullptr, 10)) : 0;
 			e.item_id     = row[8] ? static_cast<uint32_t>(strtoul(row[8], nullptr, 10)) : 0;
 
@@ -355,7 +355,7 @@ public:
 			e.recast_time = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.is_spell    = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.is_disc     = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 0;
-			e.spell_id    = row[6] ? static_cast<uint32_t>(strtoul(row[6], nullptr, 10)) : 0;
+			e.spell_id    = row[6] ? static_cast<int32_t>(atoi(row[6])) : 0;
 			e.is_item     = row[7] ? static_cast<uint8_t>(strtoul(row[7], nullptr, 10)) : 0;
 			e.item_id     = row[8] ? static_cast<uint32_t>(strtoul(row[8], nullptr, 10)) : 0;
 

--- a/common/repositories/base/base_character_buffs_repository.h
+++ b/common/repositories/base/base_character_buffs_repository.h
@@ -198,7 +198,7 @@ public:
 
 			e.character_id   = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.slot_id        = row[1] ? static_cast<uint8_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.spell_id       = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id       = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.caster_level   = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.caster_name    = row[4] ? row[4] : "";
 			e.ticsremaining  = row[5] ? static_cast<int32_t>(atoi(row[5])) : 0;
@@ -382,7 +382,7 @@ public:
 
 			e.character_id   = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.slot_id        = row[1] ? static_cast<uint8_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.spell_id       = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id       = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.caster_level   = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.caster_name    = row[4] ? row[4] : "";
 			e.ticsremaining  = row[5] ? static_cast<int32_t>(atoi(row[5])) : 0;
@@ -423,7 +423,7 @@ public:
 
 			e.character_id   = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.slot_id        = row[1] ? static_cast<uint8_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.spell_id       = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id       = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.caster_level   = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.caster_name    = row[4] ? row[4] : "";
 			e.ticsremaining  = row[5] ? static_cast<int32_t>(atoi(row[5])) : 0;

--- a/common/repositories/base/base_character_data_repository.h
+++ b/common/repositories/base/base_character_data_repository.h
@@ -132,8 +132,8 @@ public:
 		uint8_t     lfg;
 		std::string mailkey;
 		uint8_t     xtargets;
-		uint8_t     ingame;
 		uint32_t    first_login;
+		uint8_t     ingame;
 		uint32_t    e_aa_effects;
 		uint32_t    e_percent_to_aa;
 		uint32_t    e_expended_aa_spent;
@@ -248,8 +248,8 @@ public:
 			"lfg",
 			"mailkey",
 			"xtargets",
-			"ingame",
 			"first_login",
+			"ingame",
 			"e_aa_effects",
 			"e_percent_to_aa",
 			"e_expended_aa_spent",
@@ -360,8 +360,8 @@ public:
 			"lfg",
 			"mailkey",
 			"xtargets",
-			"ingame",
 			"first_login",
+			"ingame",
 			"e_aa_effects",
 			"e_percent_to_aa",
 			"e_expended_aa_spent",
@@ -506,8 +506,8 @@ public:
 		e.lfg                     = 0;
 		e.mailkey                 = "";
 		e.xtargets                = 5;
-		e.ingame                  = 0;
 		e.first_login             = 0;
+		e.ingame                  = 0;
 		e.e_aa_effects            = 0;
 		e.e_percent_to_aa         = 0;
 		e.e_expended_aa_spent     = 0;
@@ -648,8 +648,8 @@ public:
 			e.lfg                     = row[93] ? static_cast<uint8_t>(strtoul(row[93], nullptr, 10)) : 0;
 			e.mailkey                 = row[94] ? row[94] : "";
 			e.xtargets                = row[95] ? static_cast<uint8_t>(strtoul(row[95], nullptr, 10)) : 5;
-			e.ingame                  = row[96] ? static_cast<uint8_t>(strtoul(row[96], nullptr, 10)) : 0;
-			e.first_login             = row[97] ? static_cast<uint32_t>(strtoul(row[97], nullptr, 10)) : 0;
+			e.first_login             = row[96] ? static_cast<uint32_t>(strtoul(row[96], nullptr, 10)) : 0;
+			e.ingame                  = row[97] ? static_cast<uint8_t>(strtoul(row[97], nullptr, 10)) : 0;
 			e.e_aa_effects            = row[98] ? static_cast<uint32_t>(strtoul(row[98], nullptr, 10)) : 0;
 			e.e_percent_to_aa         = row[99] ? static_cast<uint32_t>(strtoul(row[99], nullptr, 10)) : 0;
 			e.e_expended_aa_spent     = row[100] ? static_cast<uint32_t>(strtoul(row[100], nullptr, 10)) : 0;
@@ -786,8 +786,8 @@ public:
 		v.push_back(columns[93] + " = " + std::to_string(e.lfg));
 		v.push_back(columns[94] + " = '" + Strings::Escape(e.mailkey) + "'");
 		v.push_back(columns[95] + " = " + std::to_string(e.xtargets));
-		v.push_back(columns[96] + " = " + std::to_string(e.ingame));
-		v.push_back(columns[97] + " = " + std::to_string(e.first_login));
+		v.push_back(columns[96] + " = " + std::to_string(e.first_login));
+		v.push_back(columns[97] + " = " + std::to_string(e.ingame));
 		v.push_back(columns[98] + " = " + std::to_string(e.e_aa_effects));
 		v.push_back(columns[99] + " = " + std::to_string(e.e_percent_to_aa));
 		v.push_back(columns[100] + " = " + std::to_string(e.e_expended_aa_spent));
@@ -913,8 +913,8 @@ public:
 		v.push_back(std::to_string(e.lfg));
 		v.push_back("'" + Strings::Escape(e.mailkey) + "'");
 		v.push_back(std::to_string(e.xtargets));
-		v.push_back(std::to_string(e.ingame));
 		v.push_back(std::to_string(e.first_login));
+		v.push_back(std::to_string(e.ingame));
 		v.push_back(std::to_string(e.e_aa_effects));
 		v.push_back(std::to_string(e.e_percent_to_aa));
 		v.push_back(std::to_string(e.e_expended_aa_spent));
@@ -1048,8 +1048,8 @@ public:
 			v.push_back(std::to_string(e.lfg));
 			v.push_back("'" + Strings::Escape(e.mailkey) + "'");
 			v.push_back(std::to_string(e.xtargets));
-			v.push_back(std::to_string(e.ingame));
 			v.push_back(std::to_string(e.first_login));
+			v.push_back(std::to_string(e.ingame));
 			v.push_back(std::to_string(e.e_aa_effects));
 			v.push_back(std::to_string(e.e_percent_to_aa));
 			v.push_back(std::to_string(e.e_expended_aa_spent));
@@ -1187,8 +1187,8 @@ public:
 			e.lfg                     = row[93] ? static_cast<uint8_t>(strtoul(row[93], nullptr, 10)) : 0;
 			e.mailkey                 = row[94] ? row[94] : "";
 			e.xtargets                = row[95] ? static_cast<uint8_t>(strtoul(row[95], nullptr, 10)) : 5;
-			e.ingame                  = row[96] ? static_cast<uint8_t>(strtoul(row[96], nullptr, 10)) : 0;
-			e.first_login             = row[97] ? static_cast<uint32_t>(strtoul(row[97], nullptr, 10)) : 0;
+			e.first_login             = row[96] ? static_cast<uint32_t>(strtoul(row[96], nullptr, 10)) : 0;
+			e.ingame                  = row[97] ? static_cast<uint8_t>(strtoul(row[97], nullptr, 10)) : 0;
 			e.e_aa_effects            = row[98] ? static_cast<uint32_t>(strtoul(row[98], nullptr, 10)) : 0;
 			e.e_percent_to_aa         = row[99] ? static_cast<uint32_t>(strtoul(row[99], nullptr, 10)) : 0;
 			e.e_expended_aa_spent     = row[100] ? static_cast<uint32_t>(strtoul(row[100], nullptr, 10)) : 0;
@@ -1317,8 +1317,8 @@ public:
 			e.lfg                     = row[93] ? static_cast<uint8_t>(strtoul(row[93], nullptr, 10)) : 0;
 			e.mailkey                 = row[94] ? row[94] : "";
 			e.xtargets                = row[95] ? static_cast<uint8_t>(strtoul(row[95], nullptr, 10)) : 5;
-			e.ingame                  = row[96] ? static_cast<uint8_t>(strtoul(row[96], nullptr, 10)) : 0;
-			e.first_login             = row[97] ? static_cast<uint32_t>(strtoul(row[97], nullptr, 10)) : 0;
+			e.first_login             = row[96] ? static_cast<uint32_t>(strtoul(row[96], nullptr, 10)) : 0;
+			e.ingame                  = row[97] ? static_cast<uint8_t>(strtoul(row[97], nullptr, 10)) : 0;
 			e.e_aa_effects            = row[98] ? static_cast<uint32_t>(strtoul(row[98], nullptr, 10)) : 0;
 			e.e_percent_to_aa         = row[99] ? static_cast<uint32_t>(strtoul(row[99], nullptr, 10)) : 0;
 			e.e_expended_aa_spent     = row[100] ? static_cast<uint32_t>(strtoul(row[100], nullptr, 10)) : 0;
@@ -1497,8 +1497,8 @@ public:
 		v.push_back(std::to_string(e.lfg));
 		v.push_back("'" + Strings::Escape(e.mailkey) + "'");
 		v.push_back(std::to_string(e.xtargets));
-		v.push_back(std::to_string(e.ingame));
 		v.push_back(std::to_string(e.first_login));
+		v.push_back(std::to_string(e.ingame));
 		v.push_back(std::to_string(e.e_aa_effects));
 		v.push_back(std::to_string(e.e_percent_to_aa));
 		v.push_back(std::to_string(e.e_expended_aa_spent));
@@ -1625,8 +1625,8 @@ public:
 			v.push_back(std::to_string(e.lfg));
 			v.push_back("'" + Strings::Escape(e.mailkey) + "'");
 			v.push_back(std::to_string(e.xtargets));
-			v.push_back(std::to_string(e.ingame));
 			v.push_back(std::to_string(e.first_login));
+			v.push_back(std::to_string(e.ingame));
 			v.push_back(std::to_string(e.e_aa_effects));
 			v.push_back(std::to_string(e.e_percent_to_aa));
 			v.push_back(std::to_string(e.e_expended_aa_spent));

--- a/common/repositories/base/base_character_exp_modifiers_repository.h
+++ b/common/repositories/base/base_character_exp_modifiers_repository.h
@@ -110,8 +110,8 @@ public:
 		e.character_id     = 0;
 		e.zone_id          = 0;
 		e.instance_version = -1;
-		e.aa_modifier      = 0;
-		e.exp_modifier     = 0;
+		e.aa_modifier      = 1;
+		e.exp_modifier     = 1;
 
 		return e;
 	}
@@ -151,8 +151,8 @@ public:
 			e.character_id     = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
 			e.zone_id          = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
 			e.instance_version = row[2] ? static_cast<int32_t>(atoi(row[2])) : -1;
-			e.aa_modifier      = row[3] ? strtof(row[3], nullptr) : 0;
-			e.exp_modifier     = row[4] ? strtof(row[4], nullptr) : 0;
+			e.aa_modifier      = row[3] ? strtof(row[3], nullptr) : 1;
+			e.exp_modifier     = row[4] ? strtof(row[4], nullptr) : 1;
 
 			return e;
 		}
@@ -287,8 +287,8 @@ public:
 			e.character_id     = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
 			e.zone_id          = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
 			e.instance_version = row[2] ? static_cast<int32_t>(atoi(row[2])) : -1;
-			e.aa_modifier      = row[3] ? strtof(row[3], nullptr) : 0;
-			e.exp_modifier     = row[4] ? strtof(row[4], nullptr) : 0;
+			e.aa_modifier      = row[3] ? strtof(row[3], nullptr) : 1;
+			e.exp_modifier     = row[4] ? strtof(row[4], nullptr) : 1;
 
 			all_entries.push_back(e);
 		}
@@ -316,8 +316,8 @@ public:
 			e.character_id     = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
 			e.zone_id          = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
 			e.instance_version = row[2] ? static_cast<int32_t>(atoi(row[2])) : -1;
-			e.aa_modifier      = row[3] ? strtof(row[3], nullptr) : 0;
-			e.exp_modifier     = row[4] ? strtof(row[4], nullptr) : 0;
+			e.aa_modifier      = row[3] ? strtof(row[3], nullptr) : 1;
+			e.exp_modifier     = row[4] ? strtof(row[4], nullptr) : 1;
 
 			all_entries.push_back(e);
 		}

--- a/common/repositories/base/base_character_memmed_spells_repository.h
+++ b/common/repositories/base/base_character_memmed_spells_repository.h
@@ -142,7 +142,7 @@ public:
 
 			e.id       = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.slot_id  = row[1] ? static_cast<uint16_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.spell_id = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 
 			return e;
 		}
@@ -270,7 +270,7 @@ public:
 
 			e.id       = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.slot_id  = row[1] ? static_cast<uint16_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.spell_id = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -297,7 +297,7 @@ public:
 
 			e.id       = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.slot_id  = row[1] ? static_cast<uint16_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.spell_id = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 
 			all_entries.push_back(e);
 		}

--- a/common/repositories/base/base_character_spells_repository.h
+++ b/common/repositories/base/base_character_spells_repository.h
@@ -142,7 +142,7 @@ public:
 
 			e.id       = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.slot_id  = row[1] ? static_cast<uint16_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.spell_id = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 
 			return e;
 		}
@@ -269,7 +269,7 @@ public:
 
 			e.id       = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.slot_id  = row[1] ? static_cast<uint16_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.spell_id = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -296,7 +296,7 @@ public:
 
 			e.id       = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.slot_id  = row[1] ? static_cast<uint16_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.spell_id = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 
 			all_entries.push_back(e);
 		}

--- a/common/repositories/base/base_damageshieldtypes_repository.h
+++ b/common/repositories/base/base_damageshieldtypes_repository.h
@@ -36,8 +36,8 @@
 class BaseDamageshieldtypesRepository {
 public:
 	struct Damageshieldtypes {
-		int32_t  spellid;
-		uint8_t  type;
+		int32_t spellid;
+		uint8_t type;
 	};
 
 	static std::string PrimaryKey()
@@ -136,7 +136,7 @@ public:
 		if (results.RowCount() == 1) {
 			Damageshieldtypes e{};
 
-			e.spellid = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.spellid = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
 			e.type    = row[1] ? static_cast<uint8_t>(strtoul(row[1], nullptr, 10)) : 0;
 
 			return e;
@@ -260,7 +260,7 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			Damageshieldtypes e{};
 
-			e.spellid = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.spellid = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
 			e.type    = row[1] ? static_cast<uint8_t>(strtoul(row[1], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
@@ -286,7 +286,7 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			Damageshieldtypes e{};
 
-			e.spellid = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.spellid = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
 			e.type    = row[1] ? static_cast<uint8_t>(strtoul(row[1], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);

--- a/common/repositories/base/base_data_buckets_repository.h
+++ b/common/repositories/base/base_data_buckets_repository.h
@@ -31,8 +31,9 @@
 #include "common/database.h"
 #include "common/strings.h"
 
+#include "cereal/cereal.hpp"
 #include <ctime>
-#include <cereal/cereal.hpp>
+
 class BaseDataBucketsRepository {
 public:
 	struct DataBuckets {

--- a/common/repositories/base/base_doors_repository.h
+++ b/common/repositories/base/base_doors_repository.h
@@ -67,7 +67,7 @@ public:
 		float       buffer;
 		uint32_t    client_version_mask;
 		int16_t     is_ldon_door;
-		int16_t     close_timer_ms;
+		uint16_t    close_timer_ms;
 		int32_t     dz_switch_id;
 		int8_t      min_expansion;
 		int8_t      max_expansion;
@@ -307,7 +307,7 @@ public:
 			e.buffer                 = row[28] ? strtof(row[28], nullptr) : 0;
 			e.client_version_mask    = row[29] ? static_cast<uint32_t>(strtoul(row[29], nullptr, 10)) : 4294967295;
 			e.is_ldon_door           = row[30] ? static_cast<int16_t>(atoi(row[30])) : 0;
-			e.close_timer_ms         = row[31] ? static_cast<int16_t>(atoi(row[31])) : 5000;
+			e.close_timer_ms         = row[31] ? static_cast<uint16_t>(strtoul(row[31], nullptr, 10)) : 5000;
 			e.dz_switch_id           = row[32] ? static_cast<int32_t>(atoi(row[32])) : 0;
 			e.min_expansion          = row[33] ? static_cast<int8_t>(atoi(row[33])) : -1;
 			e.max_expansion          = row[34] ? static_cast<int8_t>(atoi(row[34])) : -1;
@@ -570,7 +570,7 @@ public:
 			e.buffer                 = row[28] ? strtof(row[28], nullptr) : 0;
 			e.client_version_mask    = row[29] ? static_cast<uint32_t>(strtoul(row[29], nullptr, 10)) : 4294967295;
 			e.is_ldon_door           = row[30] ? static_cast<int16_t>(atoi(row[30])) : 0;
-			e.close_timer_ms         = row[31] ? static_cast<int16_t>(atoi(row[31])) : 5000;
+			e.close_timer_ms         = row[31] ? static_cast<uint16_t>(strtoul(row[31], nullptr, 10)) : 5000;
 			e.dz_switch_id           = row[32] ? static_cast<int32_t>(atoi(row[32])) : 0;
 			e.min_expansion          = row[33] ? static_cast<int8_t>(atoi(row[33])) : -1;
 			e.max_expansion          = row[34] ? static_cast<int8_t>(atoi(row[34])) : -1;
@@ -631,7 +631,7 @@ public:
 			e.buffer                 = row[28] ? strtof(row[28], nullptr) : 0;
 			e.client_version_mask    = row[29] ? static_cast<uint32_t>(strtoul(row[29], nullptr, 10)) : 4294967295;
 			e.is_ldon_door           = row[30] ? static_cast<int16_t>(atoi(row[30])) : 0;
-			e.close_timer_ms         = row[31] ? static_cast<int16_t>(atoi(row[31])) : 5000;
+			e.close_timer_ms         = row[31] ? static_cast<uint16_t>(strtoul(row[31], nullptr, 10)) : 5000;
 			e.dz_switch_id           = row[32] ? static_cast<int32_t>(atoi(row[32])) : 0;
 			e.min_expansion          = row[33] ? static_cast<int8_t>(atoi(row[33])) : -1;
 			e.max_expansion          = row[34] ? static_cast<int8_t>(atoi(row[34])) : -1;

--- a/common/repositories/base/base_guild_permissions_repository.h
+++ b/common/repositories/base/base_guild_permissions_repository.h
@@ -33,7 +33,6 @@
 
 #include <ctime>
 
-
 class BaseGuildPermissionsRepository {
 public:
 	struct GuildPermissions {
@@ -145,10 +144,10 @@ public:
 		if (results.RowCount() == 1) {
 			GuildPermissions e{};
 
-			e.id         = static_cast<int32_t>(atoi(row[0]));
-			e.perm_id    = static_cast<int32_t>(atoi(row[1]));
-			e.guild_id   = static_cast<int32_t>(atoi(row[2]));
-			e.permission = static_cast<int32_t>(atoi(row[3]));
+			e.id         = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
+			e.perm_id    = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
+			e.guild_id   = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
+			e.permission = row[3] ? static_cast<int32_t>(atoi(row[3])) : 0;
 
 			return e;
 		}
@@ -276,10 +275,10 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			GuildPermissions e{};
 
-			e.id         = static_cast<int32_t>(atoi(row[0]));
-			e.perm_id    = static_cast<int32_t>(atoi(row[1]));
-			e.guild_id   = static_cast<int32_t>(atoi(row[2]));
-			e.permission = static_cast<int32_t>(atoi(row[3]));
+			e.id         = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
+			e.perm_id    = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
+			e.guild_id   = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
+			e.permission = row[3] ? static_cast<int32_t>(atoi(row[3])) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -304,10 +303,10 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			GuildPermissions e{};
 
-			e.id         = static_cast<int32_t>(atoi(row[0]));
-			e.perm_id    = static_cast<int32_t>(atoi(row[1]));
-			e.guild_id   = static_cast<int32_t>(atoi(row[2]));
-			e.permission = static_cast<int32_t>(atoi(row[3]));
+			e.id         = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
+			e.perm_id    = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
+			e.guild_id   = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
+			e.permission = row[3] ? static_cast<int32_t>(atoi(row[3])) : 0;
 
 			all_entries.push_back(e);
 		}

--- a/common/repositories/base/base_guild_tributes_repository.h
+++ b/common/repositories/base/base_guild_tributes_repository.h
@@ -33,7 +33,6 @@
 
 #include <ctime>
 
-
 class BaseGuildTributesRepository {
 public:
 	struct GuildTributes {
@@ -157,13 +156,13 @@ public:
 		if (results.RowCount() == 1) {
 			GuildTributes e{};
 
-			e.guild_id          = static_cast<uint32_t>(strtoul(row[0], nullptr, 10));
-			e.tribute_id_1      = static_cast<uint32_t>(strtoul(row[1], nullptr, 10));
-			e.tribute_id_1_tier = static_cast<uint32_t>(strtoul(row[2], nullptr, 10));
-			e.tribute_id_2      = static_cast<uint32_t>(strtoul(row[3], nullptr, 10));
-			e.tribute_id_2_tier = static_cast<uint32_t>(strtoul(row[4], nullptr, 10));
-			e.time_remaining    = static_cast<uint32_t>(strtoul(row[5], nullptr, 10));
-			e.enabled           = static_cast<uint32_t>(strtoul(row[6], nullptr, 10));
+			e.guild_id          = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.tribute_id_1      = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.tribute_id_1_tier = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.tribute_id_2      = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
+			e.tribute_id_2_tier = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
+			e.time_remaining    = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;
+			e.enabled           = row[6] ? static_cast<uint32_t>(strtoul(row[6], nullptr, 10)) : 0;
 
 			return e;
 		}
@@ -301,13 +300,13 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			GuildTributes e{};
 
-			e.guild_id          = static_cast<uint32_t>(strtoul(row[0], nullptr, 10));
-			e.tribute_id_1      = static_cast<uint32_t>(strtoul(row[1], nullptr, 10));
-			e.tribute_id_1_tier = static_cast<uint32_t>(strtoul(row[2], nullptr, 10));
-			e.tribute_id_2      = static_cast<uint32_t>(strtoul(row[3], nullptr, 10));
-			e.tribute_id_2_tier = static_cast<uint32_t>(strtoul(row[4], nullptr, 10));
-			e.time_remaining    = static_cast<uint32_t>(strtoul(row[5], nullptr, 10));
-			e.enabled           = static_cast<uint32_t>(strtoul(row[6], nullptr, 10));
+			e.guild_id          = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.tribute_id_1      = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.tribute_id_1_tier = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.tribute_id_2      = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
+			e.tribute_id_2_tier = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
+			e.time_remaining    = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;
+			e.enabled           = row[6] ? static_cast<uint32_t>(strtoul(row[6], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -332,13 +331,13 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			GuildTributes e{};
 
-			e.guild_id          = static_cast<uint32_t>(strtoul(row[0], nullptr, 10));
-			e.tribute_id_1      = static_cast<uint32_t>(strtoul(row[1], nullptr, 10));
-			e.tribute_id_1_tier = static_cast<uint32_t>(strtoul(row[2], nullptr, 10));
-			e.tribute_id_2      = static_cast<uint32_t>(strtoul(row[3], nullptr, 10));
-			e.tribute_id_2_tier = static_cast<uint32_t>(strtoul(row[4], nullptr, 10));
-			e.time_remaining    = static_cast<uint32_t>(strtoul(row[5], nullptr, 10));
-			e.enabled           = static_cast<uint32_t>(strtoul(row[6], nullptr, 10));
+			e.guild_id          = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.tribute_id_1      = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.tribute_id_1_tier = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.tribute_id_2      = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
+			e.tribute_id_2_tier = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
+			e.time_remaining    = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;
+			e.enabled           = row[6] ? static_cast<uint32_t>(strtoul(row[6], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
 		}

--- a/common/repositories/base/base_guilds_repository.h
+++ b/common/repositories/base/base_guilds_repository.h
@@ -33,7 +33,6 @@
 
 #include <ctime>
 
-
 class BaseGuildsRepository {
 public:
 	struct Guilds {

--- a/common/repositories/base/base_ldon_trap_templates_repository.h
+++ b/common/repositories/base/base_ldon_trap_templates_repository.h
@@ -150,7 +150,7 @@ public:
 
 			e.id       = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.type     = row[1] ? static_cast<uint8_t>(strtoul(row[1], nullptr, 10)) : 1;
-			e.spell_id = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.skill    = row[3] ? static_cast<uint16_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.locked   = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 
@@ -286,7 +286,7 @@ public:
 
 			e.id       = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.type     = row[1] ? static_cast<uint8_t>(strtoul(row[1], nullptr, 10)) : 1;
-			e.spell_id = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.skill    = row[3] ? static_cast<uint16_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.locked   = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 
@@ -315,7 +315,7 @@ public:
 
 			e.id       = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.type     = row[1] ? static_cast<uint8_t>(strtoul(row[1], nullptr, 10)) : 1;
-			e.spell_id = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spell_id = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.skill    = row[3] ? static_cast<uint16_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.locked   = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 

--- a/common/repositories/base/base_merc_buffs_repository.h
+++ b/common/repositories/base/base_merc_buffs_repository.h
@@ -206,7 +206,7 @@ public:
 
 			e.MercBuffId         = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.MercId             = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.SpellId            = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.SpellId            = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.CasterLevel        = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.DurationFormula    = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.TicsRemaining      = row[5] ? static_cast<int32_t>(atoi(row[5])) : 0;
@@ -397,7 +397,7 @@ public:
 
 			e.MercBuffId         = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.MercId             = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.SpellId            = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.SpellId            = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.CasterLevel        = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.DurationFormula    = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.TicsRemaining      = row[5] ? static_cast<int32_t>(atoi(row[5])) : 0;
@@ -440,7 +440,7 @@ public:
 
 			e.MercBuffId         = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.MercId             = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.SpellId            = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.SpellId            = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.CasterLevel        = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.DurationFormula    = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.TicsRemaining      = row[5] ? static_cast<int32_t>(atoi(row[5])) : 0;

--- a/common/repositories/base/base_npc_spells_entries_repository.h
+++ b/common/repositories/base/base_npc_spells_entries_repository.h
@@ -194,7 +194,7 @@ public:
 
 			e.id                     = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.npc_spells_id          = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.spellid                = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spellid                = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.type                   = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.minlevel               = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.maxlevel               = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 255;
@@ -373,7 +373,7 @@ public:
 
 			e.id                     = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.npc_spells_id          = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.spellid                = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spellid                = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.type                   = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.minlevel               = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.maxlevel               = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 255;
@@ -413,7 +413,7 @@ public:
 
 			e.id                     = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.npc_spells_id          = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.spellid                = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.spellid                = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
 			e.type                   = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.minlevel               = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.maxlevel               = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 255;

--- a/common/repositories/base/base_player_event_log_settings_repository.h
+++ b/common/repositories/base/base_player_event_log_settings_repository.h
@@ -31,8 +31,9 @@
 #include "common/database.h"
 #include "common/strings.h"
 
+#include "cereal/cereal.hpp"
 #include <ctime>
-#include <cereal/cereal.hpp>
+
 class BasePlayerEventLogSettingsRepository {
 public:
 	struct PlayerEventLogSettings {

--- a/common/repositories/base/base_player_event_logs_repository.h
+++ b/common/repositories/base/base_player_event_logs_repository.h
@@ -31,8 +31,9 @@
 #include "common/database.h"
 #include "common/strings.h"
 
+#include "cereal/cereal.hpp"
 #include <ctime>
-#include <cereal/cereal.hpp>
+
 class BasePlayerEventLogsRepository {
 public:
 	struct PlayerEventLogs {

--- a/common/repositories/base/base_player_event_npc_handin_entries_repository.h
+++ b/common/repositories/base/base_player_event_npc_handin_entries_repository.h
@@ -49,6 +49,7 @@ public:
 		uint32_t augment_4_id;
 		uint32_t augment_5_id;
 		uint32_t augment_6_id;
+		time_t   created_at;
 	};
 
 	static std::string PrimaryKey()
@@ -72,6 +73,7 @@ public:
 			"augment_4_id",
 			"augment_5_id",
 			"augment_6_id",
+			"created_at",
 		};
 	}
 
@@ -91,6 +93,7 @@ public:
 			"augment_4_id",
 			"augment_5_id",
 			"augment_6_id",
+			"UNIX_TIMESTAMP(created_at)",
 		};
 	}
 
@@ -144,6 +147,7 @@ public:
 		e.augment_4_id               = 0;
 		e.augment_5_id               = 0;
 		e.augment_6_id               = 0;
+		e.created_at                 = 0;
 
 		return e;
 	}
@@ -193,6 +197,7 @@ public:
 			e.augment_4_id               = row[10] ? static_cast<uint32_t>(strtoul(row[10], nullptr, 10)) : 0;
 			e.augment_5_id               = row[11] ? static_cast<uint32_t>(strtoul(row[11], nullptr, 10)) : 0;
 			e.augment_6_id               = row[12] ? static_cast<uint32_t>(strtoul(row[12], nullptr, 10)) : 0;
+			e.created_at                 = strtoll(row[13] ? row[13] : "-1", nullptr, 10);
 
 			return e;
 		}
@@ -238,6 +243,7 @@ public:
 		v.push_back(columns[10] + " = " + std::to_string(e.augment_4_id));
 		v.push_back(columns[11] + " = " + std::to_string(e.augment_5_id));
 		v.push_back(columns[12] + " = " + std::to_string(e.augment_6_id));
+		v.push_back(columns[13] + " = FROM_UNIXTIME(" + (e.created_at > 0 ? std::to_string(e.created_at) : "null") + ")");
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -272,6 +278,7 @@ public:
 		v.push_back(std::to_string(e.augment_4_id));
 		v.push_back(std::to_string(e.augment_5_id));
 		v.push_back(std::to_string(e.augment_6_id));
+		v.push_back("FROM_UNIXTIME(" + (e.created_at > 0 ? std::to_string(e.created_at) : "null") + ")");
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -314,6 +321,7 @@ public:
 			v.push_back(std::to_string(e.augment_4_id));
 			v.push_back(std::to_string(e.augment_5_id));
 			v.push_back(std::to_string(e.augment_6_id));
+			v.push_back("FROM_UNIXTIME(" + (e.created_at > 0 ? std::to_string(e.created_at) : "null") + ")");
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}
@@ -360,6 +368,7 @@ public:
 			e.augment_4_id               = row[10] ? static_cast<uint32_t>(strtoul(row[10], nullptr, 10)) : 0;
 			e.augment_5_id               = row[11] ? static_cast<uint32_t>(strtoul(row[11], nullptr, 10)) : 0;
 			e.augment_6_id               = row[12] ? static_cast<uint32_t>(strtoul(row[12], nullptr, 10)) : 0;
+			e.created_at                 = strtoll(row[13] ? row[13] : "-1", nullptr, 10);
 
 			all_entries.push_back(e);
 		}
@@ -397,6 +406,7 @@ public:
 			e.augment_4_id               = row[10] ? static_cast<uint32_t>(strtoul(row[10], nullptr, 10)) : 0;
 			e.augment_5_id               = row[11] ? static_cast<uint32_t>(strtoul(row[11], nullptr, 10)) : 0;
 			e.augment_6_id               = row[12] ? static_cast<uint32_t>(strtoul(row[12], nullptr, 10)) : 0;
+			e.created_at                 = strtoll(row[13] ? row[13] : "-1", nullptr, 10);
 
 			all_entries.push_back(e);
 		}
@@ -484,6 +494,7 @@ public:
 		v.push_back(std::to_string(e.augment_4_id));
 		v.push_back(std::to_string(e.augment_5_id));
 		v.push_back(std::to_string(e.augment_6_id));
+		v.push_back("FROM_UNIXTIME(" + (e.created_at > 0 ? std::to_string(e.created_at) : "null") + ")");
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -519,6 +530,7 @@ public:
 			v.push_back(std::to_string(e.augment_4_id));
 			v.push_back(std::to_string(e.augment_5_id));
 			v.push_back(std::to_string(e.augment_6_id));
+			v.push_back("FROM_UNIXTIME(" + (e.created_at > 0 ? std::to_string(e.created_at) : "null") + ")");
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}

--- a/common/repositories/base/base_spell_buckets_repository.h
+++ b/common/repositories/base/base_spell_buckets_repository.h
@@ -144,7 +144,7 @@ public:
 		if (results.RowCount() == 1) {
 			SpellBuckets e{};
 
-			e.spell_id          = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.spell_id          = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
 			e.bucket_name       = row[1] ? row[1] : "";
 			e.bucket_value      = row[2] ? row[2] : "";
 			e.bucket_comparison = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
@@ -276,7 +276,7 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			SpellBuckets e{};
 
-			e.spell_id          = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.spell_id          = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
 			e.bucket_name       = row[1] ? row[1] : "";
 			e.bucket_value      = row[2] ? row[2] : "";
 			e.bucket_comparison = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
@@ -304,7 +304,7 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			SpellBuckets e{};
 
-			e.spell_id          = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.spell_id          = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
 			e.bucket_name       = row[1] ? row[1] : "";
 			e.bucket_value      = row[2] ? row[2] : "";
 			e.bucket_comparison = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;

--- a/common/repositories/base/base_zone_repository.h
+++ b/common/repositories/base/base_zone_repository.h
@@ -128,7 +128,7 @@ public:
 		int32_t     fast_regen_mana;
 		int32_t     fast_regen_endurance;
 		int32_t     npc_max_aggro_dist;
-		uint32_t    client_update_range;
+		int32_t     client_update_range;
 		int32_t     underworld_teleport_index;
 		int32_t     lava_damage;
 		int32_t     min_lava_damage;
@@ -616,7 +616,7 @@ public:
 			e.fast_regen_mana           = row[89] ? static_cast<int32_t>(atoi(row[89])) : 180;
 			e.fast_regen_endurance      = row[90] ? static_cast<int32_t>(atoi(row[90])) : 180;
 			e.npc_max_aggro_dist        = row[91] ? static_cast<int32_t>(atoi(row[91])) : 600;
-			e.client_update_range       = row[92] ? static_cast<uint32_t>(strtoul(row[92], nullptr, 10)) : 600;
+			e.client_update_range       = row[92] ? static_cast<int32_t>(atoi(row[92])) : 600;
 			e.underworld_teleport_index = row[93] ? static_cast<int32_t>(atoi(row[93])) : 0;
 			e.lava_damage               = row[94] ? static_cast<int32_t>(atoi(row[94])) : 50;
 			e.min_lava_damage           = row[95] ? static_cast<int32_t>(atoi(row[95])) : 10;
@@ -1127,7 +1127,7 @@ public:
 			e.fast_regen_mana           = row[89] ? static_cast<int32_t>(atoi(row[89])) : 180;
 			e.fast_regen_endurance      = row[90] ? static_cast<int32_t>(atoi(row[90])) : 180;
 			e.npc_max_aggro_dist        = row[91] ? static_cast<int32_t>(atoi(row[91])) : 600;
-			e.client_update_range       = row[92] ? static_cast<uint32_t>(strtoul(row[92], nullptr, 10)) : 600;
+			e.client_update_range       = row[92] ? static_cast<int32_t>(atoi(row[92])) : 600;
 			e.underworld_teleport_index = row[93] ? static_cast<int32_t>(atoi(row[93])) : 0;
 			e.lava_damage               = row[94] ? static_cast<int32_t>(atoi(row[94])) : 50;
 			e.min_lava_damage           = row[95] ? static_cast<int32_t>(atoi(row[95])) : 10;
@@ -1250,7 +1250,7 @@ public:
 			e.fast_regen_mana           = row[89] ? static_cast<int32_t>(atoi(row[89])) : 180;
 			e.fast_regen_endurance      = row[90] ? static_cast<int32_t>(atoi(row[90])) : 180;
 			e.npc_max_aggro_dist        = row[91] ? static_cast<int32_t>(atoi(row[91])) : 600;
-			e.client_update_range       = row[92] ? static_cast<uint32_t>(strtoul(row[92], nullptr, 10)) : 600;
+			e.client_update_range       = row[92] ? static_cast<int32_t>(atoi(row[92])) : 600;
 			e.underworld_teleport_index = row[93] ? static_cast<int32_t>(atoi(row[93])) : 0;
 			e.lava_damage               = row[94] ? static_cast<int32_t>(atoi(row[94])) : 50;
 			e.min_lava_damage           = row[95] ? static_cast<int32_t>(atoi(row[95])) : 10;

--- a/common/repositories/template/base_repository.template
+++ b/common/repositories/template/base_repository.template
@@ -1,3 +1,20 @@
+/*	EQEmu: EQEmulator
+
+	Copyright (C) 2001-2026 EQEmu Development Team
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
 /**
  * DO NOT MODIFY THIS FILE
  *

--- a/utils/scripts/generators/repository-generator.pl
+++ b/utils/scripts/generators/repository-generator.pl
@@ -152,18 +152,18 @@ foreach my $table_to_generate (@tables) {
     );
 
     foreach my $category (@categories) {
-        if ($table_to_generate ~~ $database_schema->{$category}) {
+        if ( grep {  $_ eq $table_to_generate } @{$database_schema->{$category}}) {
             $table_found_in_schema = 1;
         }
     }
 
-    if ($table_to_generate ~~ @table_ignore_list) {
+    if ( grep { $_ eq $table_to_generate } @table_ignore_list) {
         print "Table [$table_to_generate] is on ignore list... skipping...\n";
         $table_found_in_schema = 0;
     }
 
     my $cereal_enabled = 0;
-    if ($table_to_generate ~~ @cereal_enabled_tables) {
+    if ( grep { $_ eq $table_to_generate } @cereal_enabled_tables ) {
         $cereal_enabled = 1;
     }
 
@@ -425,7 +425,7 @@ foreach my $table_to_generate (@tables) {
     my $primary_key         = ($table_primary_key{$table_to_generate} ? $table_primary_key{$table_to_generate} : "");
     my $database_connection = "database";
 
-    if ($table_to_generate ~~ $database_schema->{"content_tables"}) {
+    if ( grep { $_ eq $table_to_generate } $database_schema->{"content_tables"} ) {
         $database_connection = "content_db";
     }
 
@@ -442,7 +442,7 @@ foreach my $table_to_generate (@tables) {
 		{
 			ar(\n" . $cereal_columns . "\n\t\t\t);\n\t\t}";
 
-        $additional_includes .= "#include \"cereal/cereal.hpp\"";
+        $additional_includes .= "#include \"cereal/cereal.hpp\"\n";
     }
 
     chomp($column_names_quoted);


### PR DESCRIPTION
The updates to database_update.cpp are the fixes to allow sequential merging of database migrations, it fails to migrate multiple patches without it.

The update the perl migration script is because ~~ was deprecated and had to be replaced.