### PR TITLE
Load openssl libs from executable directory and update logging

### DIFF
--- a/loginserver/CMakeLists.txt
+++ b/loginserver/CMakeLists.txt
@@ -37,3 +37,13 @@ target_include_directories(loginserver PRIVATE ..)
 
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 set_property(TARGET loginserver PROPERTY FOLDER executables/servers)
+
+# vcpkg doesn't copy legacy.dll automatically because it is loaded at runtime, not via the import table.
+if(WIN32 AND DEFINED VCPKG_INSTALLED_DIR AND DEFINED VCPKG_TARGET_TRIPLET)
+    add_custom_command(TARGET loginserver POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "$<IF:$<CONFIG:Debug>,${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/bin/legacy.dll,${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/legacy.dll>"
+            "$<TARGET_FILE_DIR:loginserver>/legacy.dll"
+        VERBATIM
+    )
+endif()

--- a/loginserver/encryption.cpp
+++ b/loginserver/encryption.cpp
@@ -31,7 +31,6 @@
 #endif
 
 #include <cstring>
-#include <filesystem>
 #include <string>
 
 #include <memory>
@@ -184,9 +183,15 @@ bool eqcrypt_init()
 {
 #ifdef EQEMU_USE_OPENSSL
 #ifdef _WIN32
-	// Set OpenSSL default provider search path to the working directory. Okay to throw.
-	std::string search_path = std::filesystem::current_path().string();
-	OSSL_PROVIDER_set_default_search_path(nullptr, search_path.c_str());
+	// Set OpenSSL default provider search path to the executable directory.
+	char* exe_path = nullptr;
+	if (_get_pgmptr(&exe_path) == 0 && exe_path != nullptr && *exe_path != '\0') {
+		std::string exe_dir{exe_path};
+		if (auto sep = exe_dir.find_last_of("\\/"); sep != std::string::npos) {
+			exe_dir.resize(sep);
+			OSSL_PROVIDER_set_default_search_path(nullptr, exe_dir.c_str());
+		}
+	}
 #endif
 
 	if (!s_default_provider) {

--- a/loginserver/encryption.cpp
+++ b/loginserver/encryption.cpp
@@ -31,6 +31,7 @@
 #endif
 
 #include <cstring>
+#include <filesystem>
 #include <string>
 
 #include <memory>
@@ -182,6 +183,12 @@ static OSSL_PROVIDER *s_default_provider = nullptr;
 bool eqcrypt_init()
 {
 #ifdef EQEMU_USE_OPENSSL
+#ifdef _WIN32
+	// Set OpenSSL default provider search path to the working directory. Okay to throw.
+	std::string search_path = std::filesystem::current_path().string();
+	OSSL_PROVIDER_set_default_search_path(nullptr, search_path.c_str());
+#endif
+
 	if (!s_default_provider) {
 		s_default_provider = OSSL_PROVIDER_load(nullptr, "default");
 	}

--- a/loginserver/main.cpp
+++ b/loginserver/main.cpp
@@ -159,17 +159,12 @@ void start_web_server()
 int main(int argc, char **argv)
 {
 	RegisterExecutablePlatform(ExePlatformLogin);
+	EQEmuLogSys::Instance()->LoadLogSettingsDefaults();
 	set_exception_handler();
 
 	if (!eqcrypt_init()) {
 		LogError("Failed to initialize crypto providers");
 		return 1;
-	}
-
-	LogInfo("Logging System Init");
-
-	if (argc == 1) {
-		EQEmuLogSys::Instance()->LoadLogSettingsDefaults();
 	}
 
 	PathManager::Instance()->Init();


### PR DESCRIPTION
The recent changes I made to fix the openssl warnings revealed a dll loading issue -- we're shipping the vcpkg compilation of openssl dlls on Windows but we're not loading them from that path. On a build system this works fine because the paths are loaded from the vcpkg folder, but it means the installation folder is not portable despite copying the required dlls. This change makes that work as expected.

I've also moved logging to be in the same order as the other executables to ensure that log messages go out as they should regardless of parameters. The parameter check previously appears to have been carried over from the desire to not log init or startup information when using the CLI parameters of loginserver. However, this seems to predate the introduction of SilenceConsoleLogging() (which was doing nothing prior to this) and it also obfuscates how error messages are logged since the logging system initializes at no logging. You can see this in the LogInfo that I removed for "Logging System Init" since it was trying to print that before logging was actually initialized. Since it didn't log before, removing it is not a behavior change.

There is a behavior change in that messages that were previously suppressed for like: `loginserver.exe login-user:create knightly secret` previously failing to connect to the database or not being able to load the server path would have been suppressed. They are now shown, which I believe is the right call regardless. If there's a behavior expectation here that needs to go along with this PR, let me know and I'll clean it up, but I think it is good as-is.

- OpenSSL is being copied to the exe directory on build but nothing was loading the local dlls
- Add OpenSSL path loading from the executable directory
- Add step to copy legacy.dll for openssl since it is a runtime dll
- This removes the requirement to install OpenSSL on the system
- Change logging to always be active when the system starts