### PR TITLE
[Bots] Fix saving of expansion settings for new bots

### DIFF
--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -512,7 +512,7 @@ bool BotDatabase::SaveNewBot(Bot* b, uint32& bot_id)
 	e.poison                 = b->GetBasePR();
 	e.disease                = b->GetBaseDR();
 	e.corruption             = b->GetBaseCorrup();
-	e.expansion_bitmask      = b->GetExpansionBitmask();
+	e.expansion_bitmask      = RuleI(Bots, BotExpansionSettings);
 
 	e = BotDataRepository::InsertOne(database, e);
 


### PR DESCRIPTION
# Description

- Bots created after #5044 weren't properly saving their default expansion settings.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Created new bots to ensure they follow server rules by default.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur


### Notes
If you don't use any underlying scripts to change expansion settings, I would recommend running:
```
SET @default_expansion = (SELECT `rule_value` FROM rule_values WHERE `rule_name` LIKE 'Bots:BotExpansionSettings');

UPDATE bot_data bd
SET bd.expansion_bitmask = @default_expansion
WHERE bd.expansion_bitmask != @default_expansion
```
