### PR TITLE
[Bots] Verify Tiger Claw on Monk Attacks

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -5335,6 +5335,12 @@ void Bot::DoClassAttacks(Mob *target, bool IsRiposte) {
 	if (ma_time) {
 		switch (GetClass()) {
 			case Class::Monk: {
+
+				if (!GetSkill(EQ::skills::SkillTigerClaw)) {
+					monkattack_timer.Disable();
+					return;
+				}
+
 				int reuse = (MonkSpecialAttack(target, EQ::skills::SkillTigerClaw) - 1);
 
 				// Live AA - Technique of Master Wu


### PR DESCRIPTION
# Description

Extra Monk Attack timer verifies the Bot actually has the Tiger Claw ability before allowing it. Previously bots underlevel could use Tiger Claw when they didn't have the skill.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Tested Monks of different levels to verify they were getting the skill properly.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
