### PR TITLE
[Combat] Monks no longer double kick

### DIFF
--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -512,29 +512,6 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk)
 
 	bool found_skill = false;
 
-	if (
-		ca_atk->m_atk == 100 &&
-		ca_atk->m_skill == EQ::skills::SkillKick &&
-		can_use_kick
-	) {
-		if (GetTarget() != this) {
-			CheckIncreaseSkill(EQ::skills::SkillKick, GetTarget(), 10);
-			DoAnim(animKick, 0, false);
-
-			int hate_override = 0;
-			if (GetWeaponDamage(GetTarget(), GetInv().GetItem(EQ::invslot::slotFeet)) <= 0) {
-				damage = -5;
-			} else {
-				hate_override = damage = GetBaseSkillDamage(EQ::skills::SkillKick, GetTarget());
-			}
-
-			reuse_time = KickReuseTime - 1 - skill_reduction;
-			DoSpecialAttackDamage(GetTarget(), EQ::skills::SkillKick, damage, 0, hate_override, reuse_time);
-
-			found_skill = true;
-		}
-	}
-
 	if (class_id == Class::Monk) {
 		reuse_time = MonkSpecialAttack(GetTarget(), ca_atk->m_skill) - 1 - skill_reduction;
 
@@ -595,6 +572,30 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk)
 		}
 
 		found_skill = true;
+	}
+	else {
+		if (
+			ca_atk->m_atk == 100 &&
+			ca_atk->m_skill == EQ::skills::SkillKick &&
+			can_use_kick
+		) {
+			if (GetTarget() != this) {
+				CheckIncreaseSkill(EQ::skills::SkillKick, GetTarget(), 10);
+				DoAnim(animKick, 0, false);
+
+				int hate_override = 0;
+				if (GetWeaponDamage(GetTarget(), GetInv().GetItem(EQ::invslot::slotFeet)) <= 0) {
+					damage = -5;
+				} else {
+					hate_override = damage = GetBaseSkillDamage(EQ::skills::SkillKick, GetTarget());
+				}
+
+				reuse_time = KickReuseTime - 1 - skill_reduction;
+				DoSpecialAttackDamage(GetTarget(), EQ::skills::SkillKick, damage, 0, hate_override, reuse_time);
+
+				found_skill = true;
+			}
+		}
 	}
 
 	if (


### PR DESCRIPTION
# Description

Monks were double kicking as they entered an additional check for Wu after the Kick check.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Verified Monks and other classes to ensure they still can kick properly and only get 1 unless they have Wu

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
