### PR TITLE
Fix CheckForCompatibleQuestPlugins to use config-driven directory paths

### DIFF
--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -95,7 +95,7 @@ void CatchSignal(int sig_num);
 
 extern void MapOpcodes();
 
-bool CheckForCompatibleQuestPlugins();
+bool CheckForCompatibleQuestPlugins(const ZoneConfig *config);
 int main(int argc, char **argv)
 {
 	RegisterExecutablePlatform(ExePlatformZone);
@@ -345,7 +345,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if (!CheckForCompatibleQuestPlugins()) {
+	if (!CheckForCompatibleQuestPlugins(Config)) {
 		LogError("Incompatible quest plugins detected, please update your plugins to the latest version");
 		return 1;
 	}
@@ -709,15 +709,15 @@ void UpdateWindowTitle(char *iNewTitle)
 #endif
 }
 
-bool CheckForCompatibleQuestPlugins()
+bool CheckForCompatibleQuestPlugins(const ZoneConfig *config)
 {
-	const std::vector<std::pair<std::string, bool *>> directories = {
-		{"lua_modules", nullptr},
-		{"plugins",     nullptr}
-	};
-
 	bool lua_found  = false;
 	bool perl_found = false;
+
+	const std::vector<std::pair<std::string, bool *>> directories = {
+		{config->LuaModuleDir, &lua_found},
+		{config->PluginDir, &perl_found}
+	};
 
 	try {
 		for (const auto &[directory, flag]: directories) {
@@ -733,12 +733,7 @@ bool CheckForCompatibleQuestPlugins()
 				auto r = File::GetContents(file_path);
 				if (!Strings::Contains(r.contents, "CheckHandin")) { continue; }
 
-				if (directory == "lua_modules") {
-					lua_found = true;
-				}
-				else {
-					perl_found = true;
-				}
+				*flag = true;
 
 				if (lua_found && perl_found) { return true; }
 			}
@@ -748,10 +743,10 @@ bool CheckForCompatibleQuestPlugins()
 	}
 
 	if (!lua_found) {
-		LogError("Failed to find CheckHandin in lua_modules");
+		LogError("Failed to find CheckHandin in the Lua Modules quest dir: {}", config->LuaModuleDir);
 	}
 	if (!perl_found) {
-		LogError("Failed to find CheckHandin in plugins");
+		LogError("Failed to find CheckHandin in the Perl plugins quest dir: {}", config->PluginDir);
 	}
 
 	return lua_found && perl_found;

--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -95,7 +95,7 @@ void CatchSignal(int sig_num);
 
 extern void MapOpcodes();
 
-bool CheckForCompatibleQuestPlugins(const ZoneConfig *config);
+bool CheckForCompatibleQuestPlugins();
 int main(int argc, char **argv)
 {
 	RegisterExecutablePlatform(ExePlatformZone);
@@ -345,7 +345,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if (!CheckForCompatibleQuestPlugins(Config)) {
+	if (!CheckForCompatibleQuestPlugins()) {
 		LogError("Incompatible quest plugins detected, please update your plugins to the latest version");
 		return 1;
 	}
@@ -709,45 +709,38 @@ void UpdateWindowTitle(char *iNewTitle)
 #endif
 }
 
-bool CheckForCompatibleQuestPlugins(const ZoneConfig *config)
+bool CheckForCompatibleQuestPlugins()
 {
 	bool lua_found  = false;
 	bool perl_found = false;
 
-	const std::vector<std::pair<std::string, bool *>> directories = {
-		{config->LuaModuleDir, &lua_found},
-		{config->PluginDir, &perl_found}
-	};
-
-	try {
-		for (const auto &[directory, flag]: directories) {
-			std::string dir_path = PathManager::Instance()->GetServerPath() + "/" + directory;
-			if (!File::Exists(dir_path)) { continue; }
-
-			for (const auto &file: fs::directory_iterator(dir_path)) {
+	auto check_dir = [&](const std::string& dir_path, bool& found) {
+		if (!File::Exists(dir_path)) { return; }
+		try {
+			for (const auto& file : fs::directory_iterator(dir_path)) {
 				if (!file.is_regular_file()) { continue; }
-
-				std::string file_path = file.path().string();
-				if (!File::Exists(file_path)) { continue; }
-
-				auto r = File::GetContents(file_path);
-				if (!Strings::Contains(r.contents, "CheckHandin")) { continue; }
-
-				*flag = true;
-
-				if (lua_found && perl_found) { return true; }
+				auto r = File::GetContents(file.path().string());
+				if (Strings::Contains(r.contents, "CheckHandin")) {
+					found = true;
+					return;
+				}
 			}
 		}
-	} catch (const fs::filesystem_error &ex) {
-		LogError("Failed to check for compatible quest plugins: {}", ex.what());
+		catch (const fs::filesystem_error& ex) {
+			LogError("Failed to check for compatible quest plugins: {}", ex.what());
+		}
+    };
+
+	for (const auto& path : PathManager::Instance()->GetLuaModulePaths()) {
+		check_dir(path, lua_found);
 	}
 
-	if (!lua_found) {
-		LogError("Failed to find CheckHandin in the Lua Modules quest dir: {}", config->LuaModuleDir);
+	for (const auto& path : PathManager::Instance()->GetPluginPaths()) {
+		check_dir(path, perl_found);
 	}
-	if (!perl_found) {
-		LogError("Failed to find CheckHandin in the Perl plugins quest dir: {}", config->PluginDir);
-	}
+
+	if (!lua_found) { LogError("Failed to find CheckHandin in the Lua module quest directories"); }
+	if (!perl_found) { LogError("Failed to find CheckHandin in the Perl plugins quest directories");}
 
 	return lua_found && perl_found;
 }


### PR DESCRIPTION
Replace hardcoded "lua_modules" string comparison with bool* flags from the directories vector, fixing lua_found never being set when LuaModuleDir is a non-default path.

# Description

The eqemu_config specifies a plugins and lua_modules directory, but it is never read and thus never used.  Currently, "plugins" and "lua_modules" are hardcoded in zone/main.cpp which means you have to have those directories symlinked from the root of your server to get zones to launch.  This is non-intuitive behavior and I've found numerous users in discord conversations get tripped up on this issue.

This change *appears* to complete the original intent of the flag pointers in the directories vector in this function.

This would only be a breaking change if users don't have their existing plugins and lua_modules directories specified correctly in their eqemu_config file.

Fixes #5098 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Testing

I tested this locally on my Windows 10 instance using Visual Studio Community 2022 and the msvc compiler.

Clients tested: Not necessary - does not affect client behavior.  This is just a quest API version check function in zone startup.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
