### PR TITLE
[Bots] Make ^itemuse use BaseRace

### DIFF
--- a/zone/bot_commands/bot_item_use.cpp
+++ b/zone/bot_commands/bot_item_use.cpp
@@ -206,8 +206,8 @@ void bot_command_item_use(Client* c, const Seperator* sep)
 		}
 
 		if (
-			(!RuleB(Bots, AllowBotEquipAnyRaceGear) && ((~item_data->Races) & GetPlayerRaceBit(bot_iter->GetRace()))) ||
-			(!RuleB(Bots, AllowBotEquipAnyClassGear) && ((~item_data->Classes) & GetPlayerClassBit(bot_iter->GetClass())))
+			(!RuleB(Bots, AllowBotEquipAnyRaceGear) && !(item_data->Races & GetPlayerRaceBit(bot_iter->GetBaseRace()))) ||
+			(!RuleB(Bots, AllowBotEquipAnyClassGear) && !(item_data->Classes & GetPlayerClassBit(bot_iter->GetClass())))
 		) {
 			continue;
 		}


### PR DESCRIPTION
# Description

Enforced `^itemuse` to use GetBaseRace instead of GetRace which could cause bots to show as usable when illusioned but unable to equip/give the bot the item.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.e)
- [x] I own the changes of my code and take responsibility for the potential issues that occur
