### PR TITLE
[Bots] Add bot owner  to hatelist on bot pet social aggro

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3186,7 +3186,11 @@ void Mob::AddToHateList(Mob* other, int64 hate /*= 0*/, int64 damage /*= 0*/, bo
 
 	// if other is a bot, add the bots client to the hate list
 	if (RuleB(Bots, Enabled)) {
-		 if (other->IsBot()) {
+		if (other->GetOwner() && other->GetOwner()->IsBot()) {
+			other = other->GetOwner();
+		}
+
+		if (other->IsBot()) {
 			auto other_ = other->CastToBot();
 
 			if (!other_ || !other_->GetBotOwner()) {


### PR DESCRIPTION
# Description

Previously when bot pets were acquiring aggro via social aggro from NPCs, the bot owner was not properly added to the hatelist and extended targets which would result in bots not doing anything to the NPC until another bot engaged the NPC or the owner did.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context. delete this line)
- [x] I own the changes of my code and take responsibility for the potential issues that occur
