### PR TITLE
[Bots] Change how bots handle blind

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -908,6 +908,7 @@ RULE_STRING(Bots, ZoneForcedSpawnLimits, "", "Comma-delimited list of forced spa
 RULE_INT(Bots, AICastSpellTypeDelay, 100, "Delay in milliseconds between AI cast attempts for each spell type. Default 100ms")
 RULE_INT(Bots, AICastSpellTypeHeldDelay, 2500, "Delay in milliseconds between AI cast attempts for each spell type that is held or disabled. Default 2500ms (2.5s)")
 RULE_BOOL(Bots, BotsRequireLoS, true, "Whether or not bots require line of sight to be told to attack their target")
+RULE_INT(Bots, BlindMoveChance, 5, "Chance for a bot to run to its target if it is blinded. Default 5.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Chat)

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -3432,6 +3432,10 @@ bool Bot::CheckIfIncapacitated() {
 	}
 
 	if (currently_fleeing) {
+		if (!FindType(SpellEffect::Fear)) { // Blinded
+			return BotProcessBlind();
+		}
+
 		if (RuleB(Combat, EnableFearPathing) && AI_movement_timer->Check()) {
 			// Check if we have reached the last fear point
 			if (DistanceNoZ(glm::vec3(GetX(), GetY(), GetZ()), m_FearWalkTarget) <= 5.0f) {
@@ -3445,6 +3449,23 @@ bool Bot::CheckIfIncapacitated() {
 				m_FearWalkTarget.y,
 				m_FearWalkTarget.z
 			);
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+bool Bot::BotProcessBlind() {
+	if (m_combat_jitter_timer.Check() && zone->random.Int(1, 100) <= RuleI(Bots, BlindMoveChance)) {
+		Mob* tar = GetTarget() ? GetTarget() : GetBotOwner();
+
+		if (tar) {
+			glm::vec3 Goal = tar->GetPosition();
+
+			RunTo(Goal.x, Goal.y, Goal.z);
+			SetCombatJitter();
 		}
 
 		return true;

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -542,7 +542,7 @@ public:
 	bool IsValidMezTarget(Mob* owner, Mob* npc, uint16 spell_id);
 
 	// Cast checks
-	bool PrecastChecks(Mob* tar, uint16 spell_type);	
+	bool PrecastChecks(Mob* tar, uint16 spell_type);
 	bool CastChecks(uint16 spell_id, Mob* tar, uint16 spell_type, bool prechecks = false, bool ae_check = false);
 	bool IsImmuneToBotSpell(uint16 spell_id, Mob* caster);
 	bool CanCastSpellType(uint16 spell_type, uint16 spell_id, Mob* tar);
@@ -1055,6 +1055,7 @@ public:
 	bool BotCastCure(Mob* tar, uint8 bot_class, BotSpell& bot_spell, uint16 spell_type);
 
 	bool CheckIfIncapacitated();
+	bool BotProcessBlind();
 	bool IsAIProcessValid(const Client* bot_owner, const Group* bot_group, const Raid* raid);
 
 	Client* SetLeashOwner(Client* bot_owner, Group* bot_group, Raid* raid, uint32 r_group) const;

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1362,6 +1362,10 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						}
 					}
 				}
+				else if (IsBot()) {
+					currently_fleeing = true;
+					CastToBot()->BotProcessBlind();
+				}
 				else if (!IsClient()) {
 					CalculateNewFearpoint();
 				}


### PR DESCRIPTION
# Description

Bots were originally running around as if they were feared when blinded and could cause unnecessary aggro.

There is a chance based off the rule `Bots:BlindMoveChance` for bots to run up to their target and ignore normal positioning. Movement adjustments are delayed behind the jitter timer.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
