### PR TITLE
[config] Change default login server

### DIFF
--- a/.devcontainer/base/eqemu_config.json
+++ b/.devcontainer/base/eqemu_config.json
@@ -32,8 +32,8 @@
 			"loginserver1": {
 				"account": "",
 				"password": "",
-				"legacy": 0,
-				"host": "login.projecteq.net",
+				"legacy": 1,
+				"host": "login.eqemulator.net",
 				"port": "5998"
 			},
 			"tcp": {


### PR DESCRIPTION
# Description
The PEQ login server is gone. We should set the EQEmu server as the default.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

N/A

Clients tested: N/A

# Checklist

- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
