### PR TITLE
Correct group member position updates when in a raid

### DIFF
--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -2102,7 +2102,7 @@ void Raid::QueueClients(Mob *sender, const EQApplicationPacket *app, bool ack_re
 				continue;
 			}
 
-			if (m.member->IsClient()) {
+			if (!m.member->IsClient()) {
 				continue;
 			}
 


### PR DESCRIPTION
Appears to have regressed in [#3125](https://github.com/EQEmu/Server/pull/3125)

# Description

Fix for groupmember positions not being updated at 300+ if in a raid.  

Position still updated if grouped and not in a raid. https://github.com/EQEmu/EQEmu/blob/b69fa9cbc/zone/groups.cpp#L2532-L2560

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Testing

Origina bug verified on RoF2.

# Checklist

- [ ] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [ ] I own the changes of my code and take responsibility for the potential issues that occur
