### PR TITLE
Multi world selector rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ skill-caps.diff
 
 # Local Multi-World Selector runtime configuration
 /world_selector.json
+MULTI_WORLD_SELECTOR_REBUILD_REPORT.md

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ compile_flags.txt
 # CMake Files
 cmake-build-relwithdebinfo/*
 skill-caps.diff
+
+# Local Multi-World Selector runtime configuration
+/world_selector.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ option(EQEMU_BUILD_SERVER "Build the game server." ON)
 option(EQEMU_BUILD_LOGIN "Build the login server." ON)
 option(EQEMU_BUILD_TESTS "Build utility tests." OFF)
 option(EQEMU_BUILD_CLIENT_FILES "Build Client Import/Export Data Programs." ON)
+option(EQEMU_BUILD_WORLD_SELECTOR "Build the EQEmu Multi-World UDP selector." OFF)
 
 if(PerlLibs_FOUND)
 	option(EQEMU_BUILD_PERL "Build Perl parser." ON)
@@ -158,7 +159,7 @@ message(STATUS "**************************************************")
 
 option(EQEMU_BUILD_LUA "Build Lua parser." ON)
 
-if(EQEMU_BUILD_SERVER OR EQEMU_BUILD_LOGIN OR EQEMU_BUILD_TESTS OR EQEMU_BUILD_CLIENT_FILES)
+if(EQEMU_BUILD_SERVER OR EQEMU_BUILD_LOGIN OR EQEMU_BUILD_TESTS OR EQEMU_BUILD_CLIENT_FILES OR EQEMU_BUILD_WORLD_SELECTOR)
 	add_subdirectory(common)
 	add_subdirectory(libs)
 else()
@@ -176,6 +177,10 @@ endif()
 
 if(EQEMU_BUILD_LOGIN)
 	add_subdirectory(loginserver)
+endif()
+
+if(EQEMU_BUILD_WORLD_SELECTOR)
+	add_subdirectory(world_selector)
 endif()
 
 if(EQEMU_BUILD_TESTS)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -61,6 +61,7 @@ set(common_sources
     md5.cpp
     memory_buffer.cpp
     memory_mapped_file.cpp
+    multi_world_selector_notifier.cpp
     memory/ksm.cpp
     misc_functions.cpp
     misc.cpp
@@ -623,6 +624,8 @@ set(common_headers
     memory_mapped_file.h
     memory/ksm.h
     misc_functions.h
+    multi_world_selector.h
+    multi_world_selector_notifier.h
     misc.h
     mysql_request_result.h
     mysql_request_row.h

--- a/common/eqemu_config.cpp
+++ b/common/eqemu_config.cpp
@@ -95,6 +95,11 @@ void EQEmuConfig::parse_config()
 
 	WorldIP      = _root["server"]["world"]["tcp"].get("ip", "127.0.0.1").asString();
 	WorldTCPPort = Strings::ToUnsignedInt(_root["server"]["world"]["tcp"].get("port", "9000").asString());
+	MultiWorldSelectorBackendIP = _root["server"]["world"]["multi_world_selector"]
+		.get("backend_bind", "0.0.0.0").asString();
+	MultiWorldSelectorBackendPort = Strings::ToUnsignedInt(
+		_root["server"]["world"]["multi_world_selector"].get("backend_port", "9000").asString()
+	);
 
 	TelnetIP      = _root["server"]["world"]["telnet"].get("ip", "127.0.0.1").asString();
 	TelnetTCPPort = Strings::ToUnsignedInt(_root["server"]["world"]["telnet"].get("port", "9001").asString());

--- a/common/eqemu_config.h
+++ b/common/eqemu_config.h
@@ -52,6 +52,8 @@ class EQEmuConfig
 		bool Locked;
 		uint16 WorldTCPPort;
 		std::string WorldIP;
+		std::string MultiWorldSelectorBackendIP;
+		uint16 MultiWorldSelectorBackendPort;
 		uint16 TelnetTCPPort;
 		std::string TelnetIP;
 		bool TelnetEnabled;

--- a/common/multi_world_selector.h
+++ b/common/multi_world_selector.h
@@ -1,0 +1,274 @@
+/*	EQEmu: EQEmulator
+
+	Copyright (C) 2001-2026 EQEmu Development Team
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 3 of the License, or
+	(at your option) any later version.
+*/
+#pragma once
+
+#include "common/json/json.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <fstream>
+#include <map>
+#include <string>
+#include <utility>
+
+namespace EQ::Net::MultiWorldSelector {
+
+constexpr std::size_t MaxWorldShortNameLength = 50;
+constexpr std::size_t ControlPacketSize       = 66;
+constexpr const char *ConfigFileName          = "world_selector.json";
+
+enum class ConfigFileLoadStatus {
+	Loaded,
+	Unavailable,
+	Malformed
+};
+
+struct WorldBackend {
+	std::string host;
+	std::uint16_t port{9000};
+};
+
+struct Config {
+	bool enabled{false};
+	std::string control_bind{"127.0.0.1"};
+	std::uint16_t control_port{9900};
+	std::string world_bind{"0.0.0.0"};
+	std::string upstream_bind{"0.0.0.0"};
+	std::uint16_t world_port{9000};
+	std::uint32_t selection_timeout_seconds{60};
+	std::uint32_t session_timeout_seconds{300};
+	std::map<std::string, WorldBackend> worlds;
+};
+
+struct ControlSelection {
+	std::string client_ip;
+	std::uint16_t login_source_port{0};
+	std::string world_short_name;
+};
+
+inline bool IsValidWorldShortName(const std::string &name)
+{
+	if (name.empty() || name.size() > MaxWorldShortNameLength) {
+		return false;
+	}
+
+	for (const auto c : name) {
+		const auto value = static_cast<unsigned char>(c);
+		if (!std::isalnum(value) && c != '_' && c != '-' && c != '.' && c != ' ') {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+inline bool IsLoopbackIPv4(const std::string &address)
+{
+	std::array<std::uint8_t, 4> octets{};
+	std::size_t start = 0;
+	for (std::size_t index = 0; index < octets.size(); ++index) {
+		const auto end = address.find('.', start);
+		if ((end == std::string::npos) != (index == octets.size() - 1)) {
+			return false;
+		}
+
+		const auto component = address.substr(start, end == std::string::npos ? end : end - start);
+		if (component.empty() || component.size() > 3) {
+			return false;
+		}
+
+		unsigned int value = 0;
+		for (const auto c : component) {
+			if (!std::isdigit(static_cast<unsigned char>(c))) {
+				return false;
+			}
+			value = value * 10 + static_cast<unsigned int>(c - '0');
+		}
+		if (value > 255) {
+			return false;
+		}
+
+		octets[index] = static_cast<std::uint8_t>(value);
+		start = end == std::string::npos ? address.size() : end + 1;
+	}
+
+	return start == address.size() && octets[0] == 127;
+}
+
+inline Config ParseConfig(const Json::Value &document)
+{
+	Config config;
+	const auto &root = document["multi_world_selector"];
+	if (!root.isObject()) {
+		return config;
+	}
+
+	try {
+		auto read_port = [](const Json::Value &value, std::uint16_t default_value) {
+			const auto parsed = value.asUInt();
+			return parsed > 0 && parsed <= 65535 ? static_cast<std::uint16_t>(parsed) :
+				(value.isNull() ? default_value : static_cast<std::uint16_t>(0));
+		};
+
+		config.enabled                   = root.get("enabled", false).asBool();
+		config.control_bind              = root.get("control_bind", "127.0.0.1").asString();
+		config.control_port              = read_port(root["control_port"], 9900);
+		config.world_bind                = root.get("world_bind", "0.0.0.0").asString();
+		config.upstream_bind             = root.get("upstream_bind", "0.0.0.0").asString();
+		config.world_port                = read_port(root["world_port"], 9000);
+		config.selection_timeout_seconds = root.get("selection_timeout_seconds", 60).asUInt();
+		config.session_timeout_seconds   = root.get("session_timeout_seconds", 300).asUInt();
+
+		const auto &worlds = root["worlds"];
+		if (worlds.isObject()) {
+			for (const auto &name : worlds.getMemberNames()) {
+				const auto &entry = worlds[name];
+				if (!entry.isObject()) {
+					continue;
+				}
+
+				WorldBackend backend;
+				backend.host = entry.get("backend_host", "").asString();
+				backend.port = read_port(entry["backend_port"], 9000);
+				config.worlds.emplace(name, std::move(backend));
+			}
+		}
+	}
+	catch (const std::exception &) {
+		return Config{};
+	}
+
+	return config;
+}
+
+inline ConfigFileLoadStatus LoadConfigFile(const std::string &path, Config &config, std::string &error)
+{
+	config = Config{};
+	error.clear();
+
+	std::ifstream file(path, std::ifstream::binary);
+	if (!file.good()) {
+		error = "unable to open selector configuration: " + path;
+		return ConfigFileLoadStatus::Unavailable;
+	}
+
+	Json::Value document;
+	Json::CharReaderBuilder reader;
+	std::string parse_error;
+	if (!Json::parseFromStream(reader, file, &document, &parse_error)) {
+		error = "unable to parse selector configuration " + path + ": " + parse_error;
+		return ConfigFileLoadStatus::Malformed;
+	}
+
+	config = ParseConfig(document);
+	return ConfigFileLoadStatus::Loaded;
+}
+
+inline void WriteUInt16(std::uint8_t *destination, std::uint16_t value)
+{
+	destination[0] = static_cast<std::uint8_t>((value >> 8) & 0xff);
+	destination[1] = static_cast<std::uint8_t>(value & 0xff);
+}
+
+inline std::uint16_t ReadUInt16(const std::uint8_t *source)
+{
+	return static_cast<std::uint16_t>((static_cast<std::uint16_t>(source[0]) << 8) | source[1]);
+}
+
+inline bool ParseIPv4Octets(const std::string &address, std::array<std::uint8_t, 4> &octets)
+{
+	std::size_t start = 0;
+	for (std::size_t index = 0; index < octets.size(); ++index) {
+		const auto end = address.find('.', start);
+		if ((end == std::string::npos) != (index == octets.size() - 1)) {
+			return false;
+		}
+
+		const auto component = address.substr(start, end == std::string::npos ? end : end - start);
+		if (component.empty() || component.size() > 3) {
+			return false;
+		}
+
+		unsigned int value = 0;
+		for (const auto c : component) {
+			if (!std::isdigit(static_cast<unsigned char>(c))) {
+				return false;
+			}
+			value = value * 10 + static_cast<unsigned int>(c - '0');
+		}
+		if (value > 255) {
+			return false;
+		}
+
+		octets[index] = static_cast<std::uint8_t>(value);
+		start = end == std::string::npos ? address.size() : end + 1;
+	}
+
+	return start == address.size();
+}
+
+inline bool EncodeControlPacket(
+	const ControlSelection &selection,
+	std::array<std::uint8_t, ControlPacketSize> &packet
+)
+{
+	std::array<std::uint8_t, 4> address{};
+	if (!ParseIPv4Octets(selection.client_ip, address) || selection.login_source_port == 0 ||
+		!IsValidWorldShortName(selection.world_short_name)) {
+		return false;
+	}
+
+	packet.fill(0);
+	packet[0] = 'E';
+	packet[1] = 'Q';
+	packet[2] = 'W';
+	packet[3] = 'S';
+	packet[4] = 1;
+	packet[5] = 0;
+	WriteUInt16(packet.data() + 6, static_cast<std::uint16_t>(packet.size()));
+	std::copy(address.begin(), address.end(), packet.begin() + 8);
+	WriteUInt16(packet.data() + 12, selection.login_source_port);
+	packet[14] = static_cast<std::uint8_t>(selection.world_short_name.size());
+	packet[15] = 0;
+	std::memcpy(packet.data() + 16, selection.world_short_name.data(), selection.world_short_name.size());
+	return true;
+}
+
+inline bool DecodeControlPacket(const std::uint8_t *data, std::size_t size, ControlSelection &selection)
+{
+	if (data == nullptr || size != ControlPacketSize ||
+		data[0] != 'E' || data[1] != 'Q' || data[2] != 'W' || data[3] != 'S' ||
+		data[4] != 1 || data[5] != 0 || ReadUInt16(data + 6) != ControlPacketSize || data[15] != 0) {
+		return false;
+	}
+
+	const auto name_length = static_cast<std::size_t>(data[14]);
+	if (name_length == 0 || name_length > MaxWorldShortNameLength || ReadUInt16(data + 12) == 0) {
+		return false;
+	}
+
+	for (std::size_t index = 16 + name_length; index < ControlPacketSize; ++index) {
+		if (data[index] != 0) {
+			return false;
+		}
+	}
+
+	selection.client_ip = std::to_string(data[8]) + "." + std::to_string(data[9]) + "." +
+		std::to_string(data[10]) + "." + std::to_string(data[11]);
+	selection.login_source_port = ReadUInt16(data + 12);
+	selection.world_short_name.assign(reinterpret_cast<const char *>(data + 16), name_length);
+	return IsValidWorldShortName(selection.world_short_name);
+}
+
+} // namespace EQ::Net::MultiWorldSelector

--- a/common/multi_world_selector_notifier.cpp
+++ b/common/multi_world_selector_notifier.cpp
@@ -1,0 +1,102 @@
+/*	EQEmu: EQEmulator
+
+	Copyright (C) 2001-2026 EQEmu Development Team
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 3 of the License, or
+	(at your option) any later version.
+*/
+#include "common/multi_world_selector_notifier.h"
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#include <cerrno>
+#include <cstring>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+namespace EQ::Net::MultiWorldSelector {
+
+bool Notify(const Config &config, const ControlSelection &selection, std::string &error)
+{
+	error.clear();
+	if (!config.enabled) {
+		return true;
+	}
+
+	if (!IsLoopbackIPv4(config.control_bind) || config.control_port == 0) {
+		error = "control_bind must be a loopback IPv4 address and control_port must be non-zero";
+		return false;
+	}
+
+	std::array<std::uint8_t, ControlPacketSize> packet{};
+	if (!EncodeControlPacket(selection, packet)) {
+		error = "invalid client IPv4 address, source port, or World short name";
+		return false;
+	}
+
+#ifdef _WIN32
+	WSADATA winsock_data{};
+	if (WSAStartup(MAKEWORD(2, 2), &winsock_data) != 0) {
+		error = "WSAStartup failed";
+		return false;
+	}
+	const auto socket_handle = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	if (socket_handle == INVALID_SOCKET) {
+		error = "socket creation failed: " + std::to_string(WSAGetLastError());
+		WSACleanup();
+		return false;
+	}
+#else
+	const auto socket_handle = socket(AF_INET, SOCK_DGRAM, 0);
+	if (socket_handle < 0) {
+		error = std::string("socket creation failed: ") + std::strerror(errno);
+		return false;
+	}
+#endif
+
+	sockaddr_in destination{};
+	destination.sin_family = AF_INET;
+	destination.sin_port   = htons(config.control_port);
+	if (inet_pton(AF_INET, config.control_bind.c_str(), &destination.sin_addr) != 1) {
+		error = "control_bind is not a numeric IPv4 address";
+#ifdef _WIN32
+		closesocket(socket_handle);
+		WSACleanup();
+#else
+		close(socket_handle);
+#endif
+		return false;
+	}
+
+	const auto sent = sendto(
+		socket_handle,
+		reinterpret_cast<const char *>(packet.data()),
+		static_cast<int>(packet.size()),
+		0,
+		reinterpret_cast<const sockaddr *>(&destination),
+		static_cast<int>(sizeof(destination))
+	);
+
+#ifdef _WIN32
+	if (sent == SOCKET_ERROR) {
+		error = "sendto failed: " + std::to_string(WSAGetLastError());
+	}
+	closesocket(socket_handle);
+	WSACleanup();
+#else
+	if (sent < 0) {
+		error = std::string("sendto failed: ") + std::strerror(errno);
+	}
+	close(socket_handle);
+#endif
+
+	return sent == static_cast<decltype(sent)>(packet.size());
+}
+
+} // namespace EQ::Net::MultiWorldSelector

--- a/common/multi_world_selector_notifier.h
+++ b/common/multi_world_selector_notifier.h
@@ -1,0 +1,22 @@
+/*	EQEmu: EQEmulator
+
+	Copyright (C) 2001-2026 EQEmu Development Team
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 3 of the License, or
+	(at your option) any later version.
+*/
+#pragma once
+
+#include "common/multi_world_selector.h"
+
+#include <string>
+
+namespace EQ::Net::MultiWorldSelector {
+
+// Best-effort by design: selector failure must never block the normal
+// loginserver-to-World authorization path.
+bool Notify(const Config &config, const ControlSelection &selection, std::string &error);
+
+} // namespace EQ::Net::MultiWorldSelector

--- a/common/net/reliable_stream_connection.cpp
+++ b/common/net/reliable_stream_connection.cpp
@@ -73,7 +73,7 @@ void EQ::Net::ReliableStreamConnectionManager::Attach(uv_loop_t *loop)
 		uv_udp_init(loop, &m_socket);
 		m_socket.data = this;
 		struct sockaddr_in recv_addr;
-		uv_ip4_addr("0.0.0.0", m_options.port, &recv_addr);
+		uv_ip4_addr(m_options.bind_address.c_str(), m_options.port, &recv_addr);
 		int rc = uv_udp_bind(&m_socket, (const struct sockaddr *)&recv_addr, UV_UDP_REUSEADDR);
 
 		rc = uv_udp_recv_start(

--- a/common/net/reliable_stream_connection.h
+++ b/common/net/reliable_stream_connection.h
@@ -319,6 +319,7 @@ namespace EQ
 			size_t connection_close_time;
 			ReliableStreamEncodeType encode_passes[2];
 			int port;
+			std::string bind_address = "0.0.0.0";
 			double outgoing_data_rate;
 		};
 

--- a/loginserver/client.cpp
+++ b/loginserver/client.cpp
@@ -19,6 +19,9 @@
 #include "login_server.h"
 #include "encryption.h"
 #include "account_management.h"
+#include "common/multi_world_selector_notifier.h"
+
+#include <algorithm>
 
 extern LoginServer server;
 
@@ -278,6 +281,50 @@ void Client::SendPlayToWorld(const char *data)
 	m_selected_play_server_id = (unsigned int) play->server_number;
 	m_play_sequence_id        = sequence_in;
 	m_selected_play_server_id = server_id_in;
+
+	const auto &selector_config = server.selector_config;
+	if (selector_config.enabled) {
+		const auto &world_servers = server.server_manager->GetWorldServers();
+		const auto selected_world = std::find_if(
+			world_servers.begin(),
+			world_servers.end(),
+			[server_id_in](const std::unique_ptr<WorldServer> &world) {
+				return world->GetServerId() == server_id_in;
+			}
+		);
+
+		if (selected_world == world_servers.end()) {
+			LogWarning(
+				"Multi-World Selector notification skipped: server ID [{}] is not currently registered",
+				server_id_in
+			);
+		}
+		else if (selector_config.worlds.find((*selected_world)->GetServerShortName()) ==
+			selector_config.worlds.end()) {
+			LogWarning(
+				"Multi-World Selector notification skipped: World [{}] is not configured",
+				(*selected_world)->GetServerShortName()
+			);
+		}
+		else {
+			EQ::Net::MultiWorldSelector::ControlSelection selection{
+				.client_ip         = m_connection->GetRemoteAddr(),
+				.login_source_port = ntohs(m_connection->GetRemotePort()),
+				.world_short_name  = (*selected_world)->GetServerShortName()
+			};
+
+			std::string notification_error;
+			if (!EQ::Net::MultiWorldSelector::Notify(selector_config, selection, notification_error)) {
+				LogWarning(
+					"Multi-World Selector notification failed for client [{}] World [{}]: {}",
+					selection.client_ip,
+					selection.world_short_name,
+					notification_error
+				);
+			}
+		}
+	}
+
 	server.server_manager->SendUserLoginToWorldRequest(server_id_in, m_account_id, m_loginserver_name);
 }
 

--- a/loginserver/login_server.h
+++ b/loginserver/login_server.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "common/json_config.h"
+#include "common/multi_world_selector.h"
 #include "loginserver/client_manager.h"
 #include "loginserver/loginserver_webserver.h"
 #include "loginserver/options.h"
@@ -31,7 +32,8 @@ public:
 
 	}
 
-	EQ::JsonConfigFile                 config;
+	EQ::JsonConfigFile                  config;
+	EQ::Net::MultiWorldSelector::Config selector_config;
 	LoginserverWebserver::TokenManager *token_manager{};
 	Options                            options;
 	WorldServerManager                 *server_manager;

--- a/loginserver/main.cpp
+++ b/loginserver/main.cpp
@@ -135,6 +135,42 @@ void LoadServerConfig()
 	server.options.AllowTokenLogin(server.config.GetVariableBool("security", "allow_token_login", false));
 }
 
+void LoadMultiWorldSelectorConfig()
+{
+	const auto config_path = fmt::format(
+		"{}/{}",
+		PathManager::Instance()->GetServerPath(),
+		EQ::Net::MultiWorldSelector::ConfigFileName
+	);
+	std::string error;
+	const auto status = EQ::Net::MultiWorldSelector::LoadConfigFile(
+		config_path,
+		server.selector_config,
+		error
+	);
+
+	if (status == EQ::Net::MultiWorldSelector::ConfigFileLoadStatus::Unavailable) {
+		LogInfo("Multi-World Selector is not configured; normal login behavior is unchanged");
+		return;
+	}
+	if (status == EQ::Net::MultiWorldSelector::ConfigFileLoadStatus::Malformed) {
+		LogWarning("Multi-World Selector notifications disabled: {}", error);
+		return;
+	}
+	if (!server.selector_config.enabled) {
+		LogInfo("Multi-World Selector is disabled; normal login behavior is unchanged");
+		return;
+	}
+	if (!EQ::Net::MultiWorldSelector::IsLoopbackIPv4(server.selector_config.control_bind) ||
+		server.selector_config.control_port == 0) {
+		LogWarning("Multi-World Selector notifications disabled: control endpoint must be loopback IPv4 with a non-zero port");
+		server.selector_config.enabled = false;
+		return;
+	}
+
+	LogInfo("Multi-World Selector notifications enabled from [{}]", config_path);
+}
+
 void start_web_server()
 {
 	Sleep(1);
@@ -184,6 +220,7 @@ int main(int argc, char **argv)
 	}
 
 	LoadServerConfig();
+	LoadMultiWorldSelectorConfig();
 	LoadDatabaseConnection();
 
 	if (argc == 1) {

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -305,7 +305,18 @@ int main(int argc, char **argv)
 
 	WorldBoot::CheckForPossibleConfigurationIssues();
 
-	EQStreamManagerInterfaceOptions opts(9000, false, false);
+	if (!IpUtil::IsIPAddress(Config->MultiWorldSelectorBackendIP) ||
+		Config->MultiWorldSelectorBackendPort == 0) {
+		LogError(
+			"Invalid server.world.multi_world_selector backend listener [{}:{}]",
+			Config->MultiWorldSelectorBackendIP,
+			Config->MultiWorldSelectorBackendPort
+		);
+		return 1;
+	}
+
+	EQStreamManagerInterfaceOptions opts(Config->MultiWorldSelectorBackendPort, false, false);
+	opts.reliable_stream_options.bind_address       = Config->MultiWorldSelectorBackendIP;
 	opts.reliable_stream_options.resend_delay_ms     = RuleI(Network, ResendDelayBaseMS);
 	opts.reliable_stream_options.resend_delay_factor = RuleR(Network, ResendDelayFactor);
 	opts.reliable_stream_options.resend_delay_min    = RuleI(Network, ResendDelayMinMS);

--- a/world_selector/CMakeLists.txt
+++ b/world_selector/CMakeLists.txt
@@ -24,6 +24,26 @@ if(WIN32)
     target_link_libraries(eqemu_world_selector Ws2_32.lib Iphlpapi.lib Userenv.lib)
 endif()
 
+if(EQEMU_BUILD_TESTS)
+    add_executable(eqemu_world_selector_tests
+        tests.cpp
+        ../common/multi_world_selector_notifier.cpp
+        ../common/multi_world_selector_notifier.h
+        selector_config_path.h
+        world_selector_server.cpp
+        world_selector_server.h
+    )
+    target_include_directories(eqemu_world_selector_tests PRIVATE ..)
+    target_link_libraries(eqemu_world_selector_tests
+        eqemu_world_selector_core
+        $<IF:$<TARGET_EXISTS:libuv::uv_a>,libuv::uv_a,libuv::uv>
+    )
+    if(WIN32)
+        target_link_libraries(eqemu_world_selector_tests Ws2_32.lib Iphlpapi.lib Userenv.lib)
+    endif()
+    set_property(TARGET eqemu_world_selector_tests PROPERTY FOLDER executables/tests)
+endif()
+
 install(TARGETS eqemu_world_selector RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 set_property(TARGET eqemu_world_selector PROPERTY FOLDER executables/servers)

--- a/world_selector/CMakeLists.txt
+++ b/world_selector/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.20)
+
+add_library(eqemu_world_selector_core STATIC
+    selector_state.cpp
+    selector_state.h
+    ../common/json/jsoncpp.cpp
+    ../common/multi_world_selector.h
+)
+target_include_directories(eqemu_world_selector_core PUBLIC ..)
+
+add_executable(eqemu_world_selector
+    main.cpp
+    selector_config_path.h
+    world_selector_server.cpp
+    world_selector_server.h
+)
+target_include_directories(eqemu_world_selector PRIVATE ..)
+target_link_libraries(eqemu_world_selector
+    eqemu_world_selector_core
+    $<IF:$<TARGET_EXISTS:libuv::uv_a>,libuv::uv_a,libuv::uv>
+)
+
+if(WIN32)
+    target_link_libraries(eqemu_world_selector Ws2_32.lib Iphlpapi.lib Userenv.lib)
+endif()
+
+install(TARGETS eqemu_world_selector RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
+set_property(TARGET eqemu_world_selector PROPERTY FOLDER executables/servers)

--- a/world_selector/main.cpp
+++ b/world_selector/main.cpp
@@ -1,0 +1,40 @@
+/*	EQEmu: EQEmulator
+
+	Copyright (C) 2001-2026 EQEmu Development Team
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 3 of the License, or
+	(at your option) any later version.
+*/
+#include "common/multi_world_selector.h"
+#include "world_selector/selector_config_path.h"
+#include "world_selector/world_selector_server.h"
+
+#include <iostream>
+#include <string>
+
+int main(int argc, char **argv)
+{
+	const auto config_path = EQ::Net::MultiWorldSelector::ResolveConfigPath(argc, argv);
+	EQ::Net::MultiWorldSelector::Config config;
+	std::string error;
+	if (EQ::Net::MultiWorldSelector::LoadConfigFile(config_path, config, error) !=
+		EQ::Net::MultiWorldSelector::ConfigFileLoadStatus::Loaded) {
+		std::cerr << error << '\n';
+		return 1;
+	}
+
+	if (!config.enabled) {
+		std::cout << "Multi-World Selector is disabled; nothing to do\n";
+		return 0;
+	}
+
+	EQ::Net::MultiWorldSelector::WorldSelectorServer server(std::move(config));
+	if (!server.Start(error)) {
+		std::cerr << "Unable to start Multi-World Selector: " << error << '\n';
+		return 1;
+	}
+
+	return server.Run();
+}

--- a/world_selector/selector_config_path.h
+++ b/world_selector/selector_config_path.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "common/multi_world_selector.h"
+
+#include <string>
+
+namespace EQ::Net::MultiWorldSelector {
+
+inline std::string ResolveConfigPath(int argc, char *const argv[])
+{
+	return argc > 1 ? argv[1] : ConfigFileName;
+}
+
+} // namespace EQ::Net::MultiWorldSelector

--- a/world_selector/selector_state.cpp
+++ b/world_selector/selector_state.cpp
@@ -28,6 +28,22 @@ bool SelectorState::AddSelection(const ControlSelection &selection, TimePoint no
 	return true;
 }
 
+bool SelectorState::HasExactPendingSelection(const ClientEndpoint &client) const
+{
+	const auto pending_by_ip = m_pending.find(client.address);
+	if (pending_by_ip == m_pending.end()) {
+		return false;
+	}
+
+	return std::any_of(
+		pending_by_ip->second.begin(),
+		pending_by_ip->second.end(),
+		[&client](const PendingSelection &selection) {
+			return selection.login_source_port == client.port;
+		}
+	);
+}
+
 std::optional<SessionRoute> SelectorState::AssignSession(const ClientEndpoint &client, TimePoint now)
 {
 	if (const auto existing = m_sessions.find(client); existing != m_sessions.end()) {

--- a/world_selector/selector_state.cpp
+++ b/world_selector/selector_state.cpp
@@ -1,0 +1,137 @@
+#include "world_selector/selector_state.h"
+
+#include <algorithm>
+
+namespace EQ::Net::MultiWorldSelector {
+
+SelectorState::SelectorState(Config config)
+:	m_config(std::move(config))
+{
+}
+
+bool SelectorState::AddSelection(const ControlSelection &selection, TimePoint now)
+{
+	std::array<std::uint8_t, 4> address{};
+	if (!ParseIPv4Octets(selection.client_ip, address) || selection.login_source_port == 0 ||
+		m_config.worlds.find(selection.world_short_name) == m_config.worlds.end()) {
+		return false;
+	}
+
+	auto &pending = m_pending[selection.client_ip];
+	std::erase_if(
+		pending,
+		[&selection](const PendingSelection &entry) {
+			return entry.login_source_port == selection.login_source_port;
+		}
+	);
+	pending.push_back({selection.login_source_port, selection.world_short_name, now});
+	return true;
+}
+
+std::optional<SessionRoute> SelectorState::AssignSession(const ClientEndpoint &client, TimePoint now)
+{
+	if (const auto existing = m_sessions.find(client); existing != m_sessions.end()) {
+		existing->second.last_activity = now;
+		return existing->second.route;
+	}
+
+	auto pending_by_ip = m_pending.find(client.address);
+	if (pending_by_ip == m_pending.end() || pending_by_ip->second.empty()) {
+		return std::nullopt;
+	}
+
+	auto &pending = pending_by_ip->second;
+	auto selection = std::find_if(
+		pending.begin(),
+		pending.end(),
+		[&client](const PendingSelection &entry) {
+			return entry.login_source_port == client.port;
+		}
+	);
+
+	// UDP NAT mappings can differ between login and World. If the source-port
+	// hint does not match, selection order is the only correlation exposed by
+	// the unmodified client and login protocol.
+	if (selection == pending.end()) {
+		selection = pending.begin();
+	}
+
+	const auto backend = m_config.worlds.find(selection->world_short_name);
+	if (backend == m_config.worlds.end()) {
+		pending.erase(selection);
+		return std::nullopt;
+	}
+
+	SessionRoute route{selection->world_short_name, backend->second};
+	pending.erase(selection);
+	if (pending.empty()) {
+		m_pending.erase(pending_by_ip);
+	}
+
+	m_sessions.emplace(client, Session{route, now});
+	return route;
+}
+
+std::optional<SessionRoute> SelectorState::GetSession(const ClientEndpoint &client) const
+{
+	const auto session = m_sessions.find(client);
+	return session == m_sessions.end() ? std::nullopt : std::optional<SessionRoute>{session->second.route};
+}
+
+void SelectorState::TouchSession(const ClientEndpoint &client, TimePoint now)
+{
+	if (auto session = m_sessions.find(client); session != m_sessions.end()) {
+		session->second.last_activity = now;
+	}
+}
+
+void SelectorState::RemoveSession(const ClientEndpoint &client)
+{
+	m_sessions.erase(client);
+}
+
+std::vector<ClientEndpoint> SelectorState::Expire(TimePoint now)
+{
+	const auto selection_timeout = std::chrono::seconds(m_config.selection_timeout_seconds);
+	for (auto pending_by_ip = m_pending.begin(); pending_by_ip != m_pending.end();) {
+		std::erase_if(
+			pending_by_ip->second,
+			[now, selection_timeout](const PendingSelection &entry) {
+				return now - entry.created_at >= selection_timeout;
+			}
+		);
+
+		if (pending_by_ip->second.empty()) {
+			pending_by_ip = m_pending.erase(pending_by_ip);
+		}
+		else {
+			++pending_by_ip;
+		}
+	}
+
+	const auto session_timeout = std::chrono::seconds(m_config.session_timeout_seconds);
+	std::vector<ClientEndpoint> expired_sessions;
+	for (const auto &[client, session] : m_sessions) {
+		if (now - session.last_activity >= session_timeout) {
+			expired_sessions.push_back(client);
+		}
+	}
+
+	return expired_sessions;
+}
+
+std::size_t SelectorState::PendingSelectionCount() const
+{
+	std::size_t count = 0;
+	for (const auto &[address, pending] : m_pending) {
+		count += pending.size();
+	}
+	return count;
+}
+
+std::size_t SelectorState::SessionCount() const
+{
+	return m_sessions.size();
+}
+
+} // namespace EQ::Net::MultiWorldSelector

--- a/world_selector/selector_state.cpp
+++ b/world_selector/selector_state.cpp
@@ -3,6 +3,15 @@
 #include <algorithm>
 
 namespace EQ::Net::MultiWorldSelector {
+namespace {
+
+bool SameRoute(const SessionRoute &left, const SessionRoute &right)
+{
+	return left.world_short_name == right.world_short_name && left.backend.host == right.backend.host &&
+		left.backend.port == right.backend.port;
+}
+
+} // namespace
 
 SelectorState::SelectorState(Config config)
 :	m_config(std::move(config))
@@ -51,41 +60,61 @@ std::optional<SessionRoute> SelectorState::AssignSession(const ClientEndpoint &c
 		return existing->second.route;
 	}
 
-	auto pending_by_ip = m_pending.find(client.address);
-	if (pending_by_ip == m_pending.end() || pending_by_ip->second.empty()) {
-		return std::nullopt;
-	}
+	if (auto pending_by_ip = m_pending.find(client.address);
+		pending_by_ip != m_pending.end() && !pending_by_ip->second.empty()) {
+		auto &pending = pending_by_ip->second;
+		auto selection = std::find_if(
+			pending.begin(),
+			pending.end(),
+			[&client](const PendingSelection &entry) {
+				return entry.login_source_port == client.port;
+			}
+		);
 
-	auto &pending = pending_by_ip->second;
-	auto selection = std::find_if(
-		pending.begin(),
-		pending.end(),
-		[&client](const PendingSelection &entry) {
-			return entry.login_source_port == client.port;
+		// UDP NAT mappings can differ between login and World. If the source-port
+		// hint does not match, selection order is the only correlation exposed by
+		// the unmodified client and login protocol.
+		if (selection == pending.end()) {
+			selection = pending.begin();
 		}
-	);
 
-	// UDP NAT mappings can differ between login and World. If the source-port
-	// hint does not match, selection order is the only correlation exposed by
-	// the unmodified client and login protocol.
-	if (selection == pending.end()) {
-		selection = pending.begin();
+		const auto backend = m_config.worlds.find(selection->world_short_name);
+		if (backend == m_config.worlds.end()) {
+			pending.erase(selection);
+			return std::nullopt;
+		}
+
+		SessionRoute route{selection->world_short_name, backend->second};
+		pending.erase(selection);
+		if (pending.empty()) {
+			m_pending.erase(pending_by_ip);
+		}
+
+		m_sessions.emplace(client, Session{route, now});
+		return route;
 	}
 
-	const auto backend = m_config.worlds.find(selection->world_short_name);
-	if (backend == m_config.worlds.end()) {
-		pending.erase(selection);
+	const auto session_timeout = std::chrono::seconds(m_config.session_timeout_seconds);
+	std::optional<SessionRoute> continuation_route;
+	for (const auto &[endpoint, session] : m_sessions) {
+		if (endpoint.address != client.address || now - session.last_activity >= session_timeout) {
+			continue;
+		}
+
+		if (!continuation_route) {
+			continuation_route = session.route;
+		}
+		else if (!SameRoute(*continuation_route, session.route)) {
+			return std::nullopt;
+		}
+	}
+
+	if (!continuation_route) {
 		return std::nullopt;
 	}
 
-	SessionRoute route{selection->world_short_name, backend->second};
-	pending.erase(selection);
-	if (pending.empty()) {
-		m_pending.erase(pending_by_ip);
-	}
-
-	m_sessions.emplace(client, Session{route, now});
-	return route;
+	m_sessions.emplace(client, Session{*continuation_route, now});
+	return continuation_route;
 }
 
 std::optional<SessionRoute> SelectorState::GetSession(const ClientEndpoint &client) const

--- a/world_selector/selector_state.h
+++ b/world_selector/selector_state.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "common/multi_world_selector.h"
+
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace EQ::Net::MultiWorldSelector {
+
+struct ClientEndpoint {
+	std::string address;
+	std::uint16_t port{0};
+
+	bool operator<(const ClientEndpoint &other) const
+	{
+		return address < other.address || (address == other.address && port < other.port);
+	}
+
+	bool operator==(const ClientEndpoint &other) const = default;
+};
+
+struct SessionRoute {
+	std::string world_short_name;
+	WorldBackend backend;
+};
+
+class SelectorState {
+public:
+	using Clock = std::chrono::steady_clock;
+	using TimePoint = Clock::time_point;
+
+	explicit SelectorState(Config config);
+
+	bool AddSelection(const ControlSelection &selection, TimePoint now);
+	std::optional<SessionRoute> AssignSession(const ClientEndpoint &client, TimePoint now);
+	std::optional<SessionRoute> GetSession(const ClientEndpoint &client) const;
+	void TouchSession(const ClientEndpoint &client, TimePoint now);
+	void RemoveSession(const ClientEndpoint &client);
+	std::vector<ClientEndpoint> Expire(TimePoint now);
+
+	std::size_t PendingSelectionCount() const;
+	std::size_t SessionCount() const;
+
+private:
+	struct PendingSelection {
+		std::uint16_t login_source_port{0};
+		std::string world_short_name;
+		TimePoint created_at;
+	};
+
+	struct Session {
+		SessionRoute route;
+		TimePoint last_activity;
+	};
+
+	Config m_config;
+	std::map<std::string, std::deque<PendingSelection>> m_pending;
+	std::map<ClientEndpoint, Session> m_sessions;
+};
+
+} // namespace EQ::Net::MultiWorldSelector

--- a/world_selector/selector_state.h
+++ b/world_selector/selector_state.h
@@ -37,6 +37,7 @@ public:
 	explicit SelectorState(Config config);
 
 	bool AddSelection(const ControlSelection &selection, TimePoint now);
+	bool HasExactPendingSelection(const ClientEndpoint &client) const;
 	std::optional<SessionRoute> AssignSession(const ClientEndpoint &client, TimePoint now);
 	std::optional<SessionRoute> GetSession(const ClientEndpoint &client) const;
 	void TouchSession(const ClientEndpoint &client, TimePoint now);

--- a/world_selector/tests.cpp
+++ b/world_selector/tests.cpp
@@ -203,6 +203,80 @@ void TestMultipleClientsAndReselection()
 	Expect(state.AssignSession(reselected, now)->world_short_name == "world_b", "reselection route failed");
 }
 
+void TestSessionRouteContinuation()
+{
+	SelectorState state(TestConfig());
+	const auto now = SelectorState::Clock::now();
+	const ClientEndpoint initial{"198.51.100.50", 46000};
+	const ClientEndpoint zoning{"198.51.100.50", 46001};
+	const ClientEndpoint second_client{"198.51.100.50", 46002};
+
+	Expect(state.AddSelection({initial.address, initial.port, "world_a"}, now),
+		"initial explicit selection rejected");
+	const auto initial_route = state.AssignSession(initial, now);
+	Expect(initial_route && initial_route->world_short_name == "world_a",
+		"initial explicit selection did not create a route");
+
+	const auto zoning_route = state.AssignSession(zoning, now + std::chrono::seconds(1));
+	Expect(zoning_route && zoning_route->world_short_name == "world_a",
+		"same-IP zoning reconnect did not inherit its route");
+
+	const auto second_client_route = state.AssignSession(second_client, now + std::chrono::seconds(2));
+	Expect(second_client_route && second_client_route->world_short_name == "world_a",
+		"multiple same-IP sessions on one backend did not allow route inheritance");
+	Expect(state.SessionCount() == 3, "continued sessions did not retain distinct UDP endpoints");
+}
+
+void TestAmbiguousRouteContinuation()
+{
+	SelectorState state(TestConfig());
+	const auto now = SelectorState::Clock::now();
+	const std::string address = "203.0.113.50";
+
+	Expect(state.AddSelection({address, 47000, "world_a"}, now), "world_a selection rejected");
+	Expect(state.AssignSession({address, 47000}, now)->world_short_name == "world_a",
+		"world_a session assignment failed");
+	Expect(state.AddSelection({address, 47001, "world_b"}, now), "world_b selection rejected");
+	Expect(state.AssignSession({address, 47001}, now)->world_short_name == "world_b",
+		"explicit world_b selection did not override same-IP inheritance");
+
+	Expect(!state.AssignSession({address, 47002}, now + std::chrono::seconds(1)),
+		"ambiguous same-IP routes were inherited");
+}
+
+void TestExplicitSelectionPrecedesContinuation()
+{
+	SelectorState state(TestConfig());
+	const auto now = SelectorState::Clock::now();
+	const std::string address = "203.0.113.60";
+
+	Expect(state.AddSelection({address, 48000, "world_a"}, now), "initial world_a selection rejected");
+	Expect(state.AssignSession({address, 48000}, now)->world_short_name == "world_a",
+		"initial world_a route failed");
+	Expect(state.AddSelection({address, 48001, "world_b"}, now), "explicit world_b selection rejected");
+	const auto selected = state.AssignSession({address, 48001}, now + std::chrono::seconds(1));
+	Expect(selected && selected->world_short_name == "world_b",
+		"same-IP route inheritance overrode an explicit selection");
+}
+
+void TestExpiredAndExactSessionContinuation()
+{
+	auto config = TestConfig();
+	config.session_timeout_seconds = 3;
+	SelectorState state(config);
+	const auto now = SelectorState::Clock::now();
+	const ClientEndpoint exact{"198.51.100.60", 49000};
+
+	Expect(state.AddSelection({exact.address, exact.port, "world_a"}, now), "exact route selection rejected");
+	Expect(state.AssignSession(exact, now)->world_short_name == "world_a", "exact route assignment failed");
+	const auto stable = state.AssignSession(exact, now + std::chrono::seconds(1));
+	Expect(stable && stable->world_short_name == "world_a", "exact active endpoint route changed");
+	Expect(state.SessionCount() == 1, "exact active endpoint created a duplicate session");
+
+	Expect(!state.AssignSession({exact.address, 49001}, now + std::chrono::seconds(4)),
+		"expired session allowed same-IP route inheritance");
+}
+
 void TestExpiryAndRestart()
 {
 	auto config = TestConfig();
@@ -255,6 +329,10 @@ int main()
 		TestControlPacketValidation();
 		TestWorldRoutingAndNatFallback();
 		TestMultipleClientsAndReselection();
+		TestSessionRouteContinuation();
+		TestAmbiguousRouteContinuation();
+		TestExplicitSelectionPrecedesContinuation();
+		TestExpiredAndExactSessionContinuation();
 		TestExpiryAndRestart();
 		TestNotificationFailureIsolation();
 	}

--- a/world_selector/tests.cpp
+++ b/world_selector/tests.cpp
@@ -1,0 +1,268 @@
+#include "common/multi_world_selector.h"
+#include "common/multi_world_selector_notifier.h"
+#include "world_selector/selector_config_path.h"
+#include "world_selector/selector_state.h"
+#include "world_selector/world_selector_server.h"
+
+#include <array>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+using namespace EQ::Net::MultiWorldSelector;
+
+namespace {
+
+void Expect(bool condition, const std::string &message)
+{
+	if (!condition) {
+		throw std::runtime_error(message);
+	}
+}
+
+std::filesystem::path UniqueConfigPath()
+{
+	static std::uint64_t sequence = 0;
+	return std::filesystem::temp_directory_path() /
+		("eqemu_world_selector_tests_" +
+			std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) + "_" +
+			std::to_string(++sequence) + ".json");
+}
+
+class TemporaryConfigFile {
+public:
+	explicit TemporaryConfigFile(const std::string &contents)
+	:	path(UniqueConfigPath())
+	{
+		std::ofstream file(path, std::ofstream::binary);
+		file << contents;
+		if (!file.good()) {
+			throw std::runtime_error("unable to create temporary selector config");
+		}
+	}
+
+	~TemporaryConfigFile()
+	{
+		std::error_code error;
+		std::filesystem::remove(path, error);
+	}
+
+	std::filesystem::path path;
+};
+
+Config TestConfig()
+{
+	Config config;
+	config.enabled = true;
+	config.selection_timeout_seconds = 60;
+	config.session_timeout_seconds = 300;
+	config.worlds.emplace("world_a", WorldBackend{"192.0.2.20", 9000});
+	config.worlds.emplace("world_b", WorldBackend{"192.0.2.30", 9000});
+	return config;
+}
+
+void TestConfigDefaults()
+{
+	const auto absent = ParseConfig(Json::Value{});
+	Expect(!absent.enabled, "absent config must disable the selector");
+	Expect(absent.control_bind == "127.0.0.1", "absent control bind changed");
+	Expect(absent.world_bind == "0.0.0.0" && absent.world_port == 9000, "absent World defaults changed");
+	Expect(absent.upstream_bind == "0.0.0.0", "absent upstream bind changed");
+	Expect(IsLoopbackIPv4("127.0.0.1"), "valid loopback address was rejected");
+	Expect(!IsLoopbackIPv4("127.bad"), "malformed loopback address was accepted");
+	Expect(!IsLoopbackIPv4("192.0.2.1"), "non-loopback address was accepted as control bind");
+
+	Json::Value document;
+	document["multi_world_selector"]["enabled"] = false;
+	document["multi_world_selector"]["world_bind"] = "192.0.2.10";
+	document["multi_world_selector"]["upstream_bind"] = "192.0.2.20";
+	const auto disabled = ParseConfig(document);
+	Expect(!disabled.enabled, "explicitly disabled config became enabled");
+	Expect(disabled.world_bind == "192.0.2.10", "explicit World bind did not parse");
+	Expect(disabled.upstream_bind == "192.0.2.20", "explicit upstream bind did not parse");
+}
+
+void TestConfigValidation()
+{
+	auto config = TestConfig();
+	std::string error;
+	Expect(ValidateConfig(config, error), "valid selector config was rejected: " + error);
+
+	config.upstream_bind = "not-an-ip";
+	error.clear();
+	Expect(!ValidateConfig(config, error), "invalid upstream bind was accepted");
+	Expect(error.find("upstream_bind") != std::string::npos, "validation error omitted upstream_bind");
+
+	config = TestConfig();
+	config.worlds["world_a"] = {config.world_bind, config.world_port};
+	error.clear();
+	Expect(!ValidateConfig(config, error), "selector relay loop was accepted");
+}
+
+void TestDedicatedConfigFileLoading()
+{
+	TemporaryConfigFile valid(R"json({
+  "multi_world_selector": {
+    "enabled": true,
+    "control_bind": "127.0.0.1",
+    "world_bind": "192.0.2.10",
+    "upstream_bind": "0.0.0.0",
+    "worlds": {
+      "world_a": { "backend_host": "192.0.2.20", "backend_port": 9000 }
+    }
+  }
+})json");
+	Config config;
+	std::string error;
+	Expect(LoadConfigFile(valid.path.string(), config, error) == ConfigFileLoadStatus::Loaded,
+		"valid dedicated config did not load: " + error);
+	Expect(config.enabled && config.worlds.count("world_a") == 1, "valid dedicated config values changed");
+
+	const auto missing_path = UniqueConfigPath();
+	Expect(LoadConfigFile(missing_path.string(), config, error) == ConfigFileLoadStatus::Unavailable,
+		"missing dedicated config was not reported unavailable");
+	Expect(!config.enabled, "missing dedicated config did not disable integration");
+
+	TemporaryConfigFile malformed("{ \"multi_world_selector\": ");
+	Expect(LoadConfigFile(malformed.path.string(), config, error) == ConfigFileLoadStatus::Malformed,
+		"malformed dedicated config was accepted");
+	Expect(!config.enabled, "malformed dedicated config did not disable integration");
+
+	TemporaryConfigFile disabled(R"json({"multi_world_selector":{"enabled":false}})json");
+	Expect(LoadConfigFile(disabled.path.string(), config, error) == ConfigFileLoadStatus::Loaded,
+		"disabled dedicated config did not load");
+	Expect(!config.enabled, "disabled dedicated config became enabled");
+}
+
+void TestSelectorConfigPath()
+{
+	char executable[] = "eqemu_world_selector.exe";
+	char *default_arguments[] = {executable};
+	Expect(ResolveConfigPath(1, default_arguments) == "world_selector.json", "default config path changed");
+
+	TemporaryConfigFile explicit_config(R"json({"multi_world_selector":{"enabled":false}})json");
+	auto explicit_path = explicit_config.path.string();
+	char *explicit_arguments[] = {executable, explicit_path.data()};
+	Expect(ResolveConfigPath(2, explicit_arguments) == explicit_path, "explicit config path was ignored");
+}
+
+void TestControlPacketValidation()
+{
+	ControlSelection input{"203.0.113.7", 45000, "world_b"};
+	std::array<std::uint8_t, ControlPacketSize> packet{};
+	Expect(EncodeControlPacket(input, packet), "valid control packet did not encode");
+
+	ControlSelection decoded;
+	Expect(DecodeControlPacket(packet.data(), packet.size(), decoded), "valid control packet did not decode");
+	Expect(decoded.client_ip == input.client_ip && decoded.login_source_port == input.login_source_port &&
+		decoded.world_short_name == input.world_short_name, "control packet round trip changed values");
+	Expect(!DecodeControlPacket(packet.data(), packet.size() - 1, decoded), "short control packet was accepted");
+	packet[0] = 'X';
+	Expect(!DecodeControlPacket(packet.data(), packet.size(), decoded), "bad control magic was accepted");
+	Expect(!EncodeControlPacket({"not-an-ip", 1, "world_a"}, packet), "bad IPv4 address was encoded");
+	Expect(!EncodeControlPacket({"203.0.113.7", 0, "world_a"}, packet), "zero source port was encoded");
+	Expect(!EncodeControlPacket({"203.0.113.7", 1, "../world_a"}, packet), "bad World name was encoded");
+}
+
+void TestWorldRoutingAndNatFallback()
+{
+	SelectorState state(TestConfig());
+	const auto now = SelectorState::Clock::now();
+	Expect(state.AddSelection({"198.51.100.10", 41000, "world_a"}, now), "world_a selection rejected");
+	Expect(state.AddSelection({"198.51.100.11", 42000, "world_b"}, now), "world_b selection rejected");
+
+	const auto world_a = state.AssignSession({"198.51.100.10", 41000}, now);
+	const auto world_b = state.AssignSession({"198.51.100.11", 52000}, now);
+	Expect(world_a && world_a->world_short_name == "world_a", "exact source-port route failed");
+	Expect(world_b && world_b->world_short_name == "world_b", "NAT fallback route failed");
+	Expect(!state.AddSelection({"198.51.100.12", 43000, "unknown"}, now), "unknown World was accepted");
+}
+
+void TestMultipleClientsAndReselection()
+{
+	SelectorState state(TestConfig());
+	const auto now = SelectorState::Clock::now();
+	Expect(state.AddSelection({"203.0.113.25", 44001, "world_a"}, now), "first NAT selection rejected");
+	Expect(state.AddSelection({"203.0.113.25", 44002, "world_b"}, now), "second NAT selection rejected");
+	Expect(state.AssignSession({"203.0.113.25", 44002}, now)->world_short_name == "world_b",
+		"exact NAT source-port hint did not win");
+	Expect(state.AssignSession({"203.0.113.25", 54001}, now)->world_short_name == "world_a",
+		"FIFO NAT fallback failed");
+	Expect(state.SessionCount() == 2, "simultaneous client sessions collided");
+
+	const ClientEndpoint reselected{"203.0.113.30", 45000};
+	Expect(state.AddSelection({reselected.address, reselected.port, "world_a"}, now), "initial route rejected");
+	Expect(state.AssignSession(reselected, now)->world_short_name == "world_a", "initial route failed");
+	Expect(state.AddSelection({reselected.address, reselected.port, "world_b"}, now), "reselection rejected");
+	Expect(state.HasExactPendingSelection(reselected), "exact reselection was not detected");
+	Expect(!state.HasExactPendingSelection({reselected.address, 45001}), "inexact reselection matched");
+	state.RemoveSession(reselected);
+	Expect(state.AssignSession(reselected, now)->world_short_name == "world_b", "reselection route failed");
+}
+
+void TestExpiryAndRestart()
+{
+	auto config = TestConfig();
+	config.selection_timeout_seconds = 2;
+	config.session_timeout_seconds = 3;
+	const auto now = SelectorState::Clock::now();
+	SelectorState state(config);
+	Expect(state.AddSelection({"198.51.100.20", 43000, "world_a"}, now), "selection rejected");
+	state.Expire(now + std::chrono::seconds(2));
+	Expect(!state.AssignSession({"198.51.100.20", 43000}, now), "stale selection did not expire");
+
+	Expect(state.AddSelection({"198.51.100.21", 43001, "world_a"}, now), "session selection rejected");
+	Expect(state.AssignSession({"198.51.100.21", 43001}, now).has_value(), "session assignment failed");
+	const auto expired = state.Expire(now + std::chrono::seconds(3));
+	Expect(expired.size() == 1, "stale session did not expire");
+
+	SelectorState restarted(config);
+	Expect(restarted.PendingSelectionCount() == 0 && restarted.SessionCount() == 0,
+		"clean restart unexpectedly persisted routes");
+}
+
+void TestNotificationFailureIsolation()
+{
+	auto config = TestConfig();
+	std::string error;
+	config.enabled = false;
+	Expect(Notify(config, {"203.0.113.40", 45000, "world_a"}, error),
+		"disabled notification did not return harmlessly");
+
+	config.enabled = true;
+	config.control_bind = "192.0.2.1";
+	Expect(!Notify(config, {"203.0.113.40", 45000, "world_a"}, error),
+		"non-loopback control destination was accepted");
+
+	config.control_bind = "127.0.0.1";
+	config.control_port = 65534; // UDP intentionally has no listener acknowledgement.
+	Expect(Notify(config, {"203.0.113.40", 45000, "world_a"}, error),
+		"unavailable selector blocked or failed the local UDP send: " + error);
+}
+
+} // namespace
+
+int main()
+{
+	try {
+		TestConfigDefaults();
+		TestConfigValidation();
+		TestDedicatedConfigFileLoading();
+		TestSelectorConfigPath();
+		TestControlPacketValidation();
+		TestWorldRoutingAndNatFallback();
+		TestMultipleClientsAndReselection();
+		TestExpiryAndRestart();
+		TestNotificationFailureIsolation();
+	}
+	catch (const std::exception &exception) {
+		std::cerr << "Multi-World Selector test failure: " << exception.what() << '\n';
+		return 1;
+	}
+
+	std::cout << "All Multi-World Selector tests passed\n";
+	return 0;
+}

--- a/world_selector/world_selector.example.json
+++ b/world_selector/world_selector.example.json
@@ -1,0 +1,22 @@
+{
+  "multi_world_selector": {
+    "enabled": false,
+    "control_bind": "127.0.0.1",
+    "control_port": 9900,
+    "world_bind": "192.0.2.10",
+    "world_port": 9000,
+    "upstream_bind": "0.0.0.0",
+    "selection_timeout_seconds": 60,
+    "session_timeout_seconds": 300,
+    "worlds": {
+      "standard_eqemu": {
+        "backend_host": "192.0.2.20",
+        "backend_port": 9000
+      },
+      "second_world": {
+        "backend_host": "192.0.2.30",
+        "backend_port": 9000
+      }
+    }
+  }
+}

--- a/world_selector/world_selector_server.cpp
+++ b/world_selector/world_selector_server.cpp
@@ -395,10 +395,18 @@ void WorldSelectorServer::ProcessWorldDatagram(const char *data, std::size_t siz
 	}
 
 	auto upstream = m_upstreams.find(client);
+	const bool is_session_request = size >= 14 && static_cast<std::uint8_t>(data[0]) == 0 &&
+		static_cast<std::uint8_t>(data[1]) == 0x01;
+	if (upstream != m_upstreams.end() && is_session_request && m_state.HasExactPendingSelection(client)) {
+		std::cout << "Replacing existing World route for reselected client "
+			<< client.address << ':' << client.port << '\n';
+		CloseSession(client);
+		upstream = m_upstreams.end();
+	}
+
 	if (upstream == m_upstreams.end()) {
 		// Only an EQ session request may consume a pending login selection.
-		if (size < 14 || static_cast<std::uint8_t>(data[0]) != 0 ||
-			static_cast<std::uint8_t>(data[1]) != 0x01) {
+		if (!is_session_request) {
 			return;
 		}
 

--- a/world_selector/world_selector_server.cpp
+++ b/world_selector/world_selector_server.cpp
@@ -1,0 +1,540 @@
+#include "world_selector/world_selector_server.h"
+
+#include <algorithm>
+#include <csignal>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+namespace EQ::Net::MultiWorldSelector {
+namespace {
+
+struct DatagramSend {
+	uv_udp_send_t request{};
+	std::vector<char> payload;
+};
+
+bool ParseSocketAddress(const std::string &address, std::uint16_t port, sockaddr_in &result)
+{
+	return uv_ip4_addr(address.c_str(), port, &result) == 0;
+}
+
+std::string SocketAddress(const sockaddr *address)
+{
+	if (address == nullptr || address->sa_family != AF_INET) {
+		return {};
+	}
+
+	char text[INET_ADDRSTRLEN]{};
+	if (uv_ip4_name(reinterpret_cast<const sockaddr_in *>(address), text, sizeof(text)) != 0) {
+		return {};
+	}
+	return text;
+}
+
+std::uint16_t SocketPort(const sockaddr *address)
+{
+	return address != nullptr && address->sa_family == AF_INET
+		? ntohs(reinterpret_cast<const sockaddr_in *>(address)->sin_port)
+		: 0;
+}
+
+bool SameSocketAddress(const sockaddr_in &expected, const sockaddr *actual)
+{
+	if (actual == nullptr || actual->sa_family != AF_INET) {
+		return false;
+	}
+	const auto *actual_ipv4 = reinterpret_cast<const sockaddr_in *>(actual);
+	return expected.sin_port == actual_ipv4->sin_port &&
+		expected.sin_addr.s_addr == actual_ipv4->sin_addr.s_addr;
+}
+
+bool SendDatagram(uv_udp_t *socket, const char *data, std::size_t size, const sockaddr *destination)
+{
+	auto send = std::make_unique<DatagramSend>();
+	send->payload.assign(data, data + size);
+	send->request.data = send.get();
+	auto buffer = uv_buf_init(send->payload.data(), static_cast<unsigned int>(send->payload.size()));
+	const auto result = uv_udp_send(
+		&send->request,
+		socket,
+		&buffer,
+		1,
+		destination,
+		[](uv_udp_send_t *request, int status) {
+			std::unique_ptr<DatagramSend> completed(static_cast<DatagramSend *>(request->data));
+			if (status < 0) {
+				std::cerr << "UDP relay send failed: " << uv_strerror(status) << '\n';
+			}
+		}
+	);
+
+	if (result < 0) {
+		std::cerr << "Unable to queue UDP relay send: " << uv_strerror(result) << '\n';
+		return false;
+	}
+
+	send.release();
+	return true;
+}
+
+} // namespace
+
+bool ValidateConfig(const Config &config, std::string &error)
+{
+	if (!config.enabled) {
+		return true;
+	}
+	if (!IsLoopbackIPv4(config.control_bind)) {
+		error = "control_bind must be a numeric IPv4 loopback address (127.0.0.0/8)";
+		return false;
+	}
+	if (config.control_port == 0 || config.world_port == 0 ||
+		config.selection_timeout_seconds == 0 || config.session_timeout_seconds == 0) {
+		error = "ports and timeout values must be non-zero";
+		return false;
+	}
+
+	sockaddr_in parsed{};
+	if (!ParseSocketAddress(config.control_bind, config.control_port, parsed) ||
+		!ParseSocketAddress(config.world_bind, config.world_port, parsed) ||
+		!ParseSocketAddress(config.upstream_bind, 0, parsed)) {
+		error = "control_bind, world_bind, and upstream_bind must be numeric IPv4 addresses";
+		return false;
+	}
+	if (config.worlds.empty()) {
+		error = "at least one World backend must be configured";
+		return false;
+	}
+
+	for (const auto &[name, backend] : config.worlds) {
+		if (!IsValidWorldShortName(name) || backend.port == 0 ||
+			!ParseSocketAddress(backend.host, backend.port, parsed)) {
+			error = "invalid World backend entry: " + name;
+			return false;
+		}
+		if (backend.host == config.world_bind && backend.port == config.world_port) {
+			error = "World backend would loop back into the selector: " + name;
+			return false;
+		}
+	}
+
+	return true;
+}
+
+WorldSelectorServer::WorldSelectorServer(Config config)
+:	m_config(std::move(config)),
+	m_state(m_config),
+	m_loop(uv_default_loop())
+{
+}
+
+WorldSelectorServer::~WorldSelectorServer() = default;
+
+bool WorldSelectorServer::Start(std::string &error)
+{
+	if (m_started) {
+		return true;
+	}
+	if (!ValidateConfig(m_config, error)) {
+		return false;
+	}
+
+	sockaddr_in control_address{};
+	sockaddr_in world_address{};
+	ParseSocketAddress(m_config.control_bind, m_config.control_port, control_address);
+	ParseSocketAddress(m_config.world_bind, m_config.world_port, world_address);
+
+	if (const auto result = uv_udp_init(m_loop, &m_control_socket); result < 0) {
+		error = std::string("unable to initialize selector control socket: ") + uv_strerror(result);
+		return false;
+	}
+	m_control_initialized = true;
+	if (const auto result = uv_udp_bind(
+		&m_control_socket,
+		reinterpret_cast<const sockaddr *>(&control_address),
+		0
+	); result < 0) {
+		error = "unable to bind selector control socket to " + m_config.control_bind + ":" +
+			std::to_string(m_config.control_port) + ": " + uv_strerror(result);
+		Stop();
+		uv_run(m_loop, UV_RUN_NOWAIT);
+		return false;
+	}
+	m_control_socket.data = this;
+
+	if (const auto result = uv_udp_init(m_loop, &m_world_socket); result < 0) {
+		error = std::string("unable to initialize selector World socket: ") + uv_strerror(result);
+		Stop();
+		uv_run(m_loop, UV_RUN_NOWAIT);
+		return false;
+	}
+	m_world_initialized = true;
+	if (const auto result = uv_udp_bind(
+		&m_world_socket,
+		reinterpret_cast<const sockaddr *>(&world_address),
+		0
+	); result < 0) {
+		error = "unable to bind selector World socket to " + m_config.world_bind + ":" +
+			std::to_string(m_config.world_port) + ": " + uv_strerror(result);
+		Stop();
+		uv_run(m_loop, UV_RUN_NOWAIT);
+		return false;
+	}
+	m_world_socket.data = this;
+
+	if (const auto result = uv_timer_init(m_loop, &m_cleanup_timer); result < 0) {
+		error = std::string("unable to initialize cleanup timer: ") + uv_strerror(result);
+		Stop();
+		uv_run(m_loop, UV_RUN_NOWAIT);
+		return false;
+	}
+	m_timer_initialized = true;
+	m_cleanup_timer.data = this;
+
+	if (const auto result = uv_signal_init(m_loop, &m_interrupt_signal); result < 0) {
+		error = std::string("unable to initialize interrupt handler: ") + uv_strerror(result);
+		Stop();
+		uv_run(m_loop, UV_RUN_NOWAIT);
+		return false;
+	}
+	m_interrupt_initialized = true;
+	m_interrupt_signal.data = this;
+
+	if (const auto result = uv_signal_init(m_loop, &m_terminate_signal); result < 0) {
+		error = std::string("unable to initialize termination handler: ") + uv_strerror(result);
+		Stop();
+		uv_run(m_loop, UV_RUN_NOWAIT);
+		return false;
+	}
+	m_terminate_initialized = true;
+	m_terminate_signal.data = this;
+
+	if (uv_udp_recv_start(&m_control_socket, AllocateBuffer, OnControlDatagram) < 0 ||
+		uv_udp_recv_start(&m_world_socket, AllocateBuffer, OnWorldDatagram) < 0) {
+		error = "unable to start UDP receive handlers";
+		Stop();
+		uv_run(m_loop, UV_RUN_NOWAIT);
+		return false;
+	}
+
+	uv_timer_start(
+		&m_cleanup_timer,
+		[](uv_timer_t *timer) {
+			static_cast<WorldSelectorServer *>(timer->data)->ExpireState();
+		},
+		1000,
+		1000
+	);
+	uv_signal_start(
+		&m_interrupt_signal,
+		[](uv_signal_t *signal, int) {
+			static_cast<WorldSelectorServer *>(signal->data)->Stop();
+		},
+		SIGINT
+	);
+	uv_signal_start(
+		&m_terminate_signal,
+		[](uv_signal_t *signal, int) {
+			static_cast<WorldSelectorServer *>(signal->data)->Stop();
+		},
+		SIGTERM
+	);
+
+	m_started = true;
+	std::cout << "Selector control listening on " << m_config.control_bind << ':' << m_config.control_port << '\n';
+	std::cout << "EQ World relay listening on " << m_config.world_bind << ':' << m_config.world_port << '\n';
+	return true;
+}
+
+int WorldSelectorServer::Run()
+{
+	return uv_run(m_loop, UV_RUN_DEFAULT);
+}
+
+void WorldSelectorServer::Stop()
+{
+	if (m_stopping) {
+		return;
+	}
+	m_stopping = true;
+
+	std::vector<ClientEndpoint> clients;
+	clients.reserve(m_upstreams.size());
+	for (const auto &[client, session] : m_upstreams) {
+		clients.push_back(client);
+	}
+	for (const auto &client : clients) {
+		CloseSession(client);
+	}
+
+	auto close_handle = [](uv_handle_t *handle) {
+		if (!uv_is_closing(handle)) {
+			uv_close(handle, nullptr);
+		}
+	};
+	if (m_control_initialized) {
+		uv_udp_recv_stop(&m_control_socket);
+		close_handle(reinterpret_cast<uv_handle_t *>(&m_control_socket));
+	}
+	if (m_world_initialized) {
+		uv_udp_recv_stop(&m_world_socket);
+		close_handle(reinterpret_cast<uv_handle_t *>(&m_world_socket));
+	}
+	if (m_timer_initialized) {
+		uv_timer_stop(&m_cleanup_timer);
+		close_handle(reinterpret_cast<uv_handle_t *>(&m_cleanup_timer));
+	}
+	if (m_interrupt_initialized) {
+		uv_signal_stop(&m_interrupt_signal);
+		close_handle(reinterpret_cast<uv_handle_t *>(&m_interrupt_signal));
+	}
+	if (m_terminate_initialized) {
+		uv_signal_stop(&m_terminate_signal);
+		close_handle(reinterpret_cast<uv_handle_t *>(&m_terminate_signal));
+	}
+	std::cout << "Selector shutdown requested; in-memory routes cleared\n";
+}
+
+void WorldSelectorServer::AllocateBuffer(uv_handle_t *, std::size_t suggested_size, uv_buf_t *buffer)
+{
+	const auto size = std::max<std::size_t>(suggested_size, 2048);
+	buffer->base = new char[size];
+	buffer->len  = static_cast<unsigned int>(size);
+}
+
+void WorldSelectorServer::OnControlDatagram(
+	uv_udp_t *handle,
+	ssize_t bytes_read,
+	const uv_buf_t *buffer,
+	const sockaddr *address,
+	unsigned int
+)
+{
+	std::unique_ptr<char[]> storage(buffer->base);
+	if (bytes_read > 0 && address != nullptr) {
+		static_cast<WorldSelectorServer *>(handle->data)->ProcessControlDatagram(
+			reinterpret_cast<const std::uint8_t *>(buffer->base),
+			static_cast<std::size_t>(bytes_read),
+			address
+		);
+	}
+}
+
+void WorldSelectorServer::OnWorldDatagram(
+	uv_udp_t *handle,
+	ssize_t bytes_read,
+	const uv_buf_t *buffer,
+	const sockaddr *address,
+	unsigned int
+)
+{
+	std::unique_ptr<char[]> storage(buffer->base);
+	if (bytes_read > 0 && address != nullptr) {
+		static_cast<WorldSelectorServer *>(handle->data)->ProcessWorldDatagram(
+			buffer->base,
+			static_cast<std::size_t>(bytes_read),
+			address
+		);
+	}
+}
+
+void WorldSelectorServer::OnBackendDatagram(
+	uv_udp_t *handle,
+	ssize_t bytes_read,
+	const uv_buf_t *buffer,
+	const sockaddr *address,
+	unsigned int
+)
+{
+	std::unique_ptr<char[]> storage(buffer->base);
+	auto *session = static_cast<UpstreamSession *>(handle->data);
+	if (bytes_read > 0 && address != nullptr && session != nullptr) {
+		session->owner->ProcessBackendDatagram(
+			*session,
+			buffer->base,
+			static_cast<std::size_t>(bytes_read),
+			address
+		);
+	}
+}
+
+void WorldSelectorServer::ProcessControlDatagram(
+	const std::uint8_t *data,
+	std::size_t size,
+	const sockaddr *address
+)
+{
+	const auto source = SocketAddress(address);
+	if (!IsLoopbackIPv4(source)) {
+		std::cerr << "Ignored selector control packet from non-loopback source " << source << '\n';
+		return;
+	}
+
+	ControlSelection selection;
+	if (!DecodeControlPacket(data, size, selection)) {
+		std::cerr << "Ignored malformed selector control packet from " << source << '\n';
+		return;
+	}
+	if (!m_state.AddSelection(selection, SelectorState::Clock::now())) {
+		std::cerr << "Ignored selector control packet for unknown World '"
+			<< selection.world_short_name << "'\n";
+		return;
+	}
+
+	std::cout << "Selection " << selection.client_ip << " -> " << selection.world_short_name
+		<< " (login source port hint " << selection.login_source_port << ")\n";
+}
+
+void WorldSelectorServer::ProcessWorldDatagram(const char *data, std::size_t size, const sockaddr *address)
+{
+	ClientEndpoint client{SocketAddress(address), SocketPort(address)};
+	if (client.address.empty() || client.port == 0) {
+		return;
+	}
+
+	auto upstream = m_upstreams.find(client);
+	if (upstream == m_upstreams.end()) {
+		// Only an EQ session request may consume a pending login selection.
+		if (size < 14 || static_cast<std::uint8_t>(data[0]) != 0 ||
+			static_cast<std::uint8_t>(data[1]) != 0x01) {
+			return;
+		}
+
+		const auto route = m_state.AssignSession(client, SelectorState::Clock::now());
+		if (!route) {
+			std::cerr << "No unexpired World selection for " << client.address << ':' << client.port << '\n';
+			return;
+		}
+
+		std::string error;
+		if (!OpenUpstream(client, *route, error)) {
+			std::cerr << error << '\n';
+			m_state.RemoveSession(client);
+			return;
+		}
+		upstream = m_upstreams.find(client);
+		std::cout << "Session " << client.address << ':' << client.port << " -> "
+			<< route->world_short_name << " (" << route->backend.host << ':' << route->backend.port << ")\n";
+	}
+
+	m_state.TouchSession(client, SelectorState::Clock::now());
+	SendDatagram(
+		&upstream->second->socket,
+		data,
+		size,
+		reinterpret_cast<const sockaddr *>(&upstream->second->backend)
+	);
+}
+
+void WorldSelectorServer::ProcessBackendDatagram(
+	UpstreamSession &session,
+	const char *data,
+	std::size_t size,
+	const sockaddr *address
+)
+{
+	if (!SameSocketAddress(session.backend, address)) {
+		std::cerr << "Ignored UDP packet from unexpected backend " << SocketAddress(address) << ':'
+			<< SocketPort(address) << '\n';
+		return;
+	}
+
+	sockaddr_in client_address{};
+	if (!ParseSocketAddress(session.client.address, session.client.port, client_address)) {
+		return;
+	}
+	m_state.TouchSession(session.client, SelectorState::Clock::now());
+	SendDatagram(
+		&m_world_socket,
+		data,
+		size,
+		reinterpret_cast<const sockaddr *>(&client_address)
+	);
+}
+
+bool WorldSelectorServer::OpenUpstream(
+	const ClientEndpoint &client,
+	const SessionRoute &route,
+	std::string &error
+)
+{
+	auto session = std::make_unique<UpstreamSession>();
+	session->owner  = this;
+	session->client = client;
+	if (!ParseSocketAddress(route.backend.host, route.backend.port, session->backend)) {
+		error = "invalid backend address for World " + route.world_short_name;
+		return false;
+	}
+
+	const auto initialized = uv_udp_init(m_loop, &session->socket);
+	if (initialized < 0) {
+		error = std::string("unable to initialize upstream socket: ") + uv_strerror(initialized);
+		return false;
+	}
+	session->socket.data = session.get();
+
+	sockaddr_in source{};
+	ParseSocketAddress(m_config.upstream_bind, 0, source);
+	const auto bound = uv_udp_bind(&session->socket, reinterpret_cast<const sockaddr *>(&source), 0);
+	if (bound < 0) {
+		error = std::string("unable to bind ephemeral upstream socket: ") + uv_strerror(bound);
+		uv_close(
+			reinterpret_cast<uv_handle_t *>(&session->socket),
+			[](uv_handle_t *handle) {
+				delete static_cast<UpstreamSession *>(handle->data);
+			}
+		);
+		session.release();
+		return false;
+	}
+
+	const auto receiving = uv_udp_recv_start(&session->socket, AllocateBuffer, OnBackendDatagram);
+	if (receiving < 0) {
+		error = std::string("unable to receive backend replies: ") + uv_strerror(receiving);
+		uv_close(
+			reinterpret_cast<uv_handle_t *>(&session->socket),
+			[](uv_handle_t *handle) {
+				delete static_cast<UpstreamSession *>(handle->data);
+			}
+		);
+		session.release();
+		return false;
+	}
+
+	m_upstreams.emplace(client, session.release());
+	return true;
+}
+
+void WorldSelectorServer::CloseSession(const ClientEndpoint &client)
+{
+	const auto session = m_upstreams.find(client);
+	if (session == m_upstreams.end()) {
+		m_state.RemoveSession(client);
+		return;
+	}
+
+	auto *upstream = session->second;
+	m_upstreams.erase(session);
+	m_state.RemoveSession(client);
+	uv_udp_recv_stop(&upstream->socket);
+	if (!uv_is_closing(reinterpret_cast<uv_handle_t *>(&upstream->socket))) {
+		uv_close(
+			reinterpret_cast<uv_handle_t *>(&upstream->socket),
+			[](uv_handle_t *handle) {
+				delete static_cast<UpstreamSession *>(handle->data);
+			}
+		);
+	}
+}
+
+void WorldSelectorServer::ExpireState()
+{
+	for (const auto &client : m_state.Expire(SelectorState::Clock::now())) {
+		std::cout << "Expired World session " << client.address << ':' << client.port << '\n';
+		CloseSession(client);
+	}
+}
+
+} // namespace EQ::Net::MultiWorldSelector

--- a/world_selector/world_selector_server.h
+++ b/world_selector/world_selector_server.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "world_selector/selector_state.h"
+
+#include <map>
+#include <string>
+
+#include <uv.h>
+
+namespace EQ::Net::MultiWorldSelector {
+
+class WorldSelectorServer {
+public:
+	explicit WorldSelectorServer(Config config);
+	~WorldSelectorServer();
+
+	bool Start(std::string &error);
+	int Run();
+	void Stop();
+
+private:
+	struct UpstreamSession {
+		uv_udp_t socket{};
+		WorldSelectorServer *owner{};
+		ClientEndpoint client;
+		sockaddr_in backend{};
+	};
+
+	static void AllocateBuffer(uv_handle_t *handle, std::size_t suggested_size, uv_buf_t *buffer);
+	static void OnControlDatagram(
+		uv_udp_t *handle,
+		ssize_t bytes_read,
+		const uv_buf_t *buffer,
+		const sockaddr *address,
+		unsigned int flags
+	);
+	static void OnWorldDatagram(
+		uv_udp_t *handle,
+		ssize_t bytes_read,
+		const uv_buf_t *buffer,
+		const sockaddr *address,
+		unsigned int flags
+	);
+	static void OnBackendDatagram(
+		uv_udp_t *handle,
+		ssize_t bytes_read,
+		const uv_buf_t *buffer,
+		const sockaddr *address,
+		unsigned int flags
+	);
+
+	void ProcessControlDatagram(const std::uint8_t *data, std::size_t size, const sockaddr *address);
+	void ProcessWorldDatagram(const char *data, std::size_t size, const sockaddr *address);
+	void ProcessBackendDatagram(UpstreamSession &session, const char *data, std::size_t size, const sockaddr *address);
+	bool OpenUpstream(const ClientEndpoint &client, const SessionRoute &route, std::string &error);
+	void CloseSession(const ClientEndpoint &client);
+	void ExpireState();
+
+	Config m_config;
+	SelectorState m_state;
+	uv_loop_t *m_loop{};
+	uv_udp_t m_control_socket{};
+	uv_udp_t m_world_socket{};
+	uv_timer_t m_cleanup_timer{};
+	uv_signal_t m_interrupt_signal{};
+	uv_signal_t m_terminate_signal{};
+	bool m_started{false};
+	bool m_stopping{false};
+	bool m_control_initialized{false};
+	bool m_world_initialized{false};
+	bool m_timer_initialized{false};
+	bool m_interrupt_initialized{false};
+	bool m_terminate_initialized{false};
+	std::map<ClientEndpoint, UpstreamSession *> m_upstreams;
+};
+
+bool ValidateConfig(const Config &config, std::string &error);
+
+} // namespace EQ::Net::MultiWorldSelector


### PR DESCRIPTION
# Description

Adds an optional Multi World Selector that allows multiple EQEmu World instances to run on the same host using separate IP bindings.

The selector receives the player's world selection from the Login Server and routes the client's UDP session to the appropriate backend World instance.

The implementation is opt-in. Existing single-world EQEmu behavior remains unchanged when the selector is not configured or enabled.

This change includes:

* A standalone `eqemu_world_selector` service.
* Login Server notification of player world selections.
* Routing of client UDP sessions to the selected backend World.
* Support for separate selector and backend World bind addresses.
* Handling for World reconnects across client UDP ports.
* Handling for reused client sessions and world reselection.
* An example selector configuration.
* Automated selector tests.
* CMake/build integration for the selector and tests.

This is intended for hosts that run multiple independent EQEmu World instances on one physical machine and have multiple IP addresses available for those worlds.

No database schema changes are required.

No additional external dependencies are required beyond the existing EQEmu build dependencies.

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

# Testing

The selector was built and tested locally with multiple World/IP bindings.

Testing included:

* Selector startup and configuration loading.
* Login Server to selector world-selection notifications.
* Routing clients to the selected backend World.
* Reusing client sessions and selecting another World.
* Backend World reconnect handling.
* Client UDP port changes/reconnects.
* Selector and normal World binding to separate local IP addresses.
* Operation with the selector disabled so normal single-world behavior remains available.
* Automated tests included under `world_selector/tests.cpp`.

Clients tested: RoF2

# Checklist

* [x] I have tested my changes
* [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
* [x] I own the changes of my code and take responsibility for the potential issues that occur
